### PR TITLE
ENH: Trainable regularisation and adjustable SearchAlgo

### DIFF
--- a/config/r_local_linreg.json
+++ b/config/r_local_linreg.json
@@ -6,6 +6,7 @@
   ],
   "max_cuncurrent_trials": 5,
   "num_trials": 2,
+  "optuna_searchspace_sampler": "TPESampler",
   "seed_data": 12,
   "seed_model": 12,
   "target": "age_months",

--- a/config/r_local_linreg_py.json
+++ b/config/r_local_linreg_py.json
@@ -6,6 +6,7 @@
   ],
   "max_cuncurrent_trials": 5,
   "num_trials": 2,
+  "optuna_searchspace_sampler": "TPESampler",
   "seed_data": 12,
   "seed_model": 12,
   "target": "age_months",

--- a/config/run_config.json
+++ b/config/run_config.json
@@ -12,6 +12,7 @@
   ],
   "max_cuncurrent_trials": 5,
   "num_trials": 2,
+  "optuna_searchspace_sampler": "TPESampler",
   "seed_data": 12,
   "seed_model": 12,
   "target": "age_months",

--- a/config/run_config_whparams.json
+++ b/config/run_config_whparams.json
@@ -29,6 +29,21 @@
         128,
         256
       ],
+      "dropout_rate": {
+        "max": 0.5,
+        "min": 0.0,
+        "step": 0.05
+      },
+      "early_stopping_min_delta": {
+        "log": true,
+        "max": 0.01,
+        "min": 1e-05
+      },
+      "early_stopping_patience": {
+        "max": 10,
+        "min": 2,
+        "step": 1
+      },
       "epochs": [
         10,
         50,
@@ -55,7 +70,12 @@
         128,
         256,
         512
-      ]
+      ],
+      "weight_decay": {
+        "log": true,
+        "max": 0.01,
+        "min": 1e-06
+      }
     },
     "rf": {
       "bootstrap": [
@@ -141,12 +161,12 @@
       "reg_alpha": {
         "log": true,
         "max": 1.0,
-        "min": 0.0
+        "min": 1e-10
       },
       "reg_lambda": {
         "log": true,
         "max": 1.0,
-        "min": 0.0
+        "min": 1e-10
       },
       "subsample": {
         "max": 1.0,

--- a/config/run_config_whparams.json
+++ b/config/run_config_whparams.json
@@ -175,6 +175,7 @@
     }
   },
   "num_trials": 2,
+  "optuna_searchspace_sampler": "TPESampler",
   "seed_data": 12,
   "seed_model": 12,
   "target": "age_months",

--- a/config/run_config_whparams.json
+++ b/config/run_config_whparams.json
@@ -112,9 +112,18 @@
       }
     },
     "xgb": {
+      "colsample_bytree": {
+        "max": 1.0,
+        "min": 0.3
+      },
       "eta": {
         "max": 0.3,
         "min": 0.01
+      },
+      "gamma": {
+        "max": 5.0,
+        "min": 0.0,
+        "step": 0.1
       },
       "max_depth": {
         "max": 10,
@@ -128,6 +137,16 @@
         "max": 3,
         "min": 1,
         "step": 1
+      },
+      "reg_alpha": {
+        "log": true,
+        "max": 1.0,
+        "min": 0.0
+      },
+      "reg_lambda": {
+        "log": true,
+        "max": 1.0,
+        "min": 0.0
       },
       "subsample": {
         "max": 1.0,

--- a/ritme/find_best_model_config.py
+++ b/ritme/find_best_model_config.py
@@ -193,6 +193,9 @@ def find_best_model_config(
         model_types=config["ls_model_types"],
         fully_reproducible=False,
         model_hyperparameters=config.get("model_hyperparameters", {}),
+        optuna_searchspace_sampler=config.get(
+            "optuna_searchspace_sampler", "TPESampler"
+        ),
     )
 
     # ! Get best models of this experiment

--- a/ritme/model_space/static_searchspace.py
+++ b/ritme/model_space/static_searchspace.py
@@ -214,6 +214,37 @@ def get_xgb_space(trial, tax, model_hyperparameters: dict = {}) -> Dict[str, Any
         step=num_parallel_tree["step"],
     )
 
+    # Additional regularization hyperparameters
+    # Minimum loss reduction required for a split: Larger values make the
+    # algorithm more conservative - less overfitting. 0 = no regularization
+    gamma = model_hyperparameters.get("gamma", {"min": 0.0, "max": 5.0, "step": 0.1})
+    trial.suggest_float("gamma", gamma["min"], gamma["max"], step=gamma["step"])
+
+    # L1 penalty term
+    reg_alpha = model_hyperparameters.get(
+        "reg_alpha", {"min": 0.0, "max": 1.0, "log": True}
+    )
+    trial.suggest_float(
+        "reg_alpha", reg_alpha["min"], reg_alpha["max"], log=reg_alpha["log"]
+    )
+
+    # L2 penalty term
+    reg_lambda = model_hyperparameters.get(
+        "reg_lambda", {"min": 0.0, "max": 1.0, "log": True}
+    )
+    trial.suggest_float(
+        "reg_lambda", reg_lambda["min"], reg_lambda["max"], log=reg_lambda["log"]
+    )
+
+    # randomly subsample Fraction of features to use in each tree. Lower values
+    # reduce overfitting by limiting feature usage.
+    colsample_bytree = model_hyperparameters.get(
+        "colsample_bytree", {"min": 0.3, "max": 1.0}
+    )
+    trial.suggest_float(
+        "colsample_bytree", colsample_bytree["min"], colsample_bytree["max"]
+    )
+
     return {"model": "xgb"}
 
 

--- a/ritme/model_space/static_searchspace.py
+++ b/ritme/model_space/static_searchspace.py
@@ -171,10 +171,56 @@ def get_nn_space(
     epochs = model_hyperparameters.get("epochs", [10, 50, 100, 200])
     trial.suggest_categorical("epochs", epochs)
 
-    # first and last layer are fixed by shape of features and target
+    # hidden-layer sizes: first and last layer are fixed by shape of features
+    # and target
     n_units_hl = model_hyperparameters.get("n_units_hl", [32, 64, 128, 256, 512])
     for i in range(n_hidden_layers):
         trial.suggest_categorical(f"n_units_hl{i}", n_units_hl)
+
+    # regularisation options:
+    # dropout
+    dropout_range = model_hyperparameters.get(
+        "dropout_rate", {"min": 0.0, "max": 0.5, "step": 0.05}
+    )
+    trial.suggest_float(
+        "dropout_rate",
+        dropout_range["min"],
+        dropout_range["max"],
+        step=dropout_range["step"],
+    )
+
+    # weight decay
+    wd_range = model_hyperparameters.get(
+        "weight_decay", {"min": 1e-6, "max": 1e-2, "log": True}
+    )
+    trial.suggest_float(
+        "weight_decay",
+        wd_range["min"],
+        wd_range["max"],
+        log=wd_range["log"],
+    )
+
+    # early stopping patience range: number of epochs with no improvement
+    es_range = model_hyperparameters.get(
+        "early_stopping_patience", {"min": 2, "max": 10, "step": 1}
+    )
+    trial.suggest_int(
+        "early_stopping_patience",
+        es_range["min"],
+        es_range["max"],
+        step=es_range["step"],
+    )
+
+    # early stopping min_delta range
+    es_delta_range = model_hyperparameters.get(
+        "early_stopping_min_delta", {"min": 1e-5, "max": 1e-2, "log": True}
+    )
+    trial.suggest_float(
+        "early_stopping_min_delta",
+        es_delta_range["min"],
+        es_delta_range["max"],
+        log=es_delta_range["log"],
+    )
 
     return {"model": model_name}
 
@@ -222,7 +268,7 @@ def get_xgb_space(trial, tax, model_hyperparameters: dict = {}) -> Dict[str, Any
 
     # L1 penalty term
     reg_alpha = model_hyperparameters.get(
-        "reg_alpha", {"min": 0.0, "max": 1.0, "log": True}
+        "reg_alpha", {"min": 1e-10, "max": 1.0, "log": True}
     )
     trial.suggest_float(
         "reg_alpha", reg_alpha["min"], reg_alpha["max"], log=reg_alpha["log"]
@@ -230,7 +276,7 @@ def get_xgb_space(trial, tax, model_hyperparameters: dict = {}) -> Dict[str, Any
 
     # L2 penalty term
     reg_lambda = model_hyperparameters.get(
-        "reg_lambda", {"min": 0.0, "max": 1.0, "log": True}
+        "reg_lambda", {"min": 1e-10, "max": 1.0, "log": True}
     )
     trial.suggest_float(
         "reg_lambda", reg_lambda["min"], reg_lambda["max"], log=reg_lambda["log"]

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -299,6 +299,12 @@ def train_rf(
     rf = RandomForestRegressor(
         n_estimators=config["n_estimators"],
         max_depth=config["max_depth"],
+        min_samples_split=config["min_samples_split"],
+        min_weight_fraction_leaf=config["min_weight_fraction_leaf"],
+        min_samples_leaf=config["min_samples_leaf"],
+        max_features=config["max_features"],
+        min_impurity_decrease=config["min_impurity_decrease"],
+        bootstrap=config["bootstrap"],
         # ray tune uses joblib for parallelization - so this makes sure all
         # available resources are used
         n_jobs=None,

--- a/ritme/tests/test_config_files.py
+++ b/ritme/tests/test_config_files.py
@@ -107,6 +107,10 @@ class TestConfigFiles(unittest.TestCase):
                     "batch_size": None,
                     "epochs": None,
                     "n_units_hl": None,
+                    "dropout_rate": ["min", "max", "step"],
+                    "weight_decay": ["min", "max", "log"],
+                    "early_stopping_patience": ["min", "max", "step"],
+                    "early_stopping_min_delta": ["min", "max", "log"],
                 },
             ),
             (

--- a/ritme/tests/test_config_files.py
+++ b/ritme/tests/test_config_files.py
@@ -117,6 +117,10 @@ class TestConfigFiles(unittest.TestCase):
                     "subsample": ["min", "max"],
                     "eta": ["min", "max"],
                     "num_parallel_tree": ["min", "max", "step"],
+                    "gamma": ["min", "max", "step"],
+                    "reg_alpha": ["min", "max", "log"],
+                    "reg_lambda": ["min", "max", "log"],
+                    "colsample_bytree": ["min", "max"],
                 },
             ),
             (
@@ -130,8 +134,16 @@ class TestConfigFiles(unittest.TestCase):
         with open(config_path) as f:
             run_config = json.load(f)
 
+        # Check if all keys in hparams are present in run_config
         for k, v in hparams.items():
             self.assertIn(k, run_config["model_hyperparameters"][model])
             if v is not None:
                 for vi in v:
                     self.assertIn(vi, run_config["model_hyperparameters"][model][k])
+
+        # Check if all keys in run_config are present in hparams
+        for k_config, v_config in run_config["model_hyperparameters"][model].items():
+            self.assertIn(k_config, hparams)
+            if hparams[k_config] is not None:
+                for vi_config in hparams[k_config]:
+                    self.assertIn(vi_config, v_config)

--- a/ritme/tests/test_config_files.py
+++ b/ritme/tests/test_config_files.py
@@ -35,6 +35,8 @@ class TestConfigFiles(unittest.TestCase):
     @parameterized.expand(
         [
             "run_config.json",
+            "r_local_linreg.json",
+            "r_local_linreg_py.json",
             "run_config_whparams.json",
         ]
     )

--- a/ritme/tests/test_find_best_model_config.py
+++ b/ritme/tests/test_find_best_model_config.py
@@ -224,6 +224,7 @@ class TestFindBestModelConfig(unittest.TestCase):
                 model_types=self.config["ls_model_types"],
                 fully_reproducible=False,
                 model_hyperparameters={},
+                optuna_searchspace_sampler="TPESampler",
             )
 
             mock_retrieve_n_init_best_models.assert_called_once_with(

--- a/ritme/tests/test_model_static_searchspace.py
+++ b/ritme/tests/test_model_static_searchspace.py
@@ -28,6 +28,7 @@ class TestStaticSearchSpace(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.tax = pd.DataFrame()
+        self.data_params_prefix = "data_"
 
     @parameterized.expand(
         [
@@ -55,24 +56,33 @@ class TestStaticSearchSpace(unittest.TestCase):
         linreg_space = ss.get_linreg_space(trial, self.tax)
         self.assertIsInstance(linreg_space, dict)
         self.assertEqual(linreg_space["model"], "linreg")
+
+        trial_model_params = {
+            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
+        }
         expected_params = {"alpha", "l1_ratio"}
-        self.assertTrue(expected_params.issubset(trial.params.keys()))
+        self.assertSetEqual(trial_model_params, expected_params)
 
     def test_get_rf_space(self):
         trial = MockTrial()
         rf_space = ss.get_rf_space(trial, self.tax)
         self.assertIsInstance(rf_space, dict)
         self.assertEqual(rf_space["model"], "rf")
+
+        trial_model_params = {
+            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
+        }
         expected_params = {
             "n_estimators",
             "max_depth",
             "min_samples_split",
+            "min_weight_fraction_leaf",
             "min_samples_leaf",
             "max_features",
             "min_impurity_decrease",
             "bootstrap",
         }
-        self.assertTrue(expected_params.issubset(trial.params.keys()))
+        self.assertSetEqual(trial_model_params, expected_params)
 
     @parameterized.expand(
         [
@@ -88,8 +98,16 @@ class TestStaticSearchSpace(unittest.TestCase):
         self.assertIsInstance(nn_space, dict)
         self.assertEqual(nn_space["model"], model_type)
 
-        expected_params = {"n_hidden_layers", "learning_rate", "batch_size", "epochs"}
-        self.assertTrue(expected_params.issubset(trial.params.keys()))
+        trial_model_params = {
+            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
+        }
+        expected_params = {
+            "n_hidden_layers",
+            "learning_rate",
+            "batch_size",
+            "epochs",
+        }.union({f"n_units_hl{i}" for i in range(5)})
+        self.assertSetEqual(trial_model_params, expected_params)
 
         self.assertTrue(any(f"n_units_hl{i}" in trial.params for i in range(30)))
 
@@ -98,14 +116,22 @@ class TestStaticSearchSpace(unittest.TestCase):
         xgb_space = ss.get_xgb_space(trial, self.tax)
         self.assertIsInstance(xgb_space, dict)
         self.assertEqual(xgb_space["model"], "xgb")
+
+        trial_model_params = {
+            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
+        }
         expected_params = {
             "max_depth",
             "min_child_weight",
             "subsample",
             "eta",
             "num_parallel_tree",
+            "gamma",
+            "reg_alpha",
+            "reg_lambda",
+            "colsample_bytree",
         }
-        self.assertTrue(expected_params.issubset(trial.params.keys()))
+        self.assertSetEqual(trial_model_params, expected_params)
 
     def test_get_trac_space(self):
         trial = MockTrial()

--- a/ritme/tests/test_model_static_searchspace.py
+++ b/ritme/tests/test_model_static_searchspace.py
@@ -204,6 +204,7 @@ class TestStaticSearchSpace(unittest.TestCase):
                     "gamma": {"min": 0.1, "max": 3.0, "step": 0.1},
                     "reg_alpha": {"min": 0.1, "max": 0.5, "log": True},
                     "reg_lambda": {"min": 0.1, "max": 0.5, "log": True},
+                    "colsample_bytree": {"min": 0.7, "max": 0.8},
                 },
             ),
             (

--- a/ritme/tests/test_model_static_searchspace.py
+++ b/ritme/tests/test_model_static_searchspace.py
@@ -106,6 +106,10 @@ class TestStaticSearchSpace(unittest.TestCase):
             "learning_rate",
             "batch_size",
             "epochs",
+            "dropout_rate",
+            "weight_decay",
+            "early_stopping_patience",
+            "early_stopping_min_delta",
         }.union({f"n_units_hl{i}" for i in range(5)})
         self.assertSetEqual(trial_model_params, expected_params)
 
@@ -197,6 +201,9 @@ class TestStaticSearchSpace(unittest.TestCase):
                     "subsample": {"min": 0.8, "max": 1.0},
                     "eta": {"min": 0.05, "max": 0.2, "log": True},
                     "num_parallel_tree": {"min": 2, "max": 4, "step": 1},
+                    "gamma": {"min": 0.1, "max": 3.0, "step": 0.1},
+                    "reg_alpha": {"min": 0.1, "max": 0.5, "log": True},
+                    "reg_lambda": {"min": 0.1, "max": 0.5, "log": True},
                 },
             ),
             (
@@ -207,6 +214,14 @@ class TestStaticSearchSpace(unittest.TestCase):
                     "batch_size": [64, 128],
                     "epochs": [50, 100],
                     "n_units_hl": [64, 128, 256],
+                    "dropout_rate": {"min": 0.1, "max": 0.3},
+                    "weight_decay": {"min": 0.0001, "max": 0.001, "log": True},
+                    "early_stopping_patience": {"min": 5, "max": 20, "step": 5},
+                    "early_stopping_min_delta": {
+                        "min": 0.001,
+                        "max": 0.01,
+                        "log": True,
+                    },
                 },
             ),
         ]
@@ -285,6 +300,10 @@ class TestStaticSearchSpace(unittest.TestCase):
                     "subsample": {"min": 0.7, "max": 1.0},
                     "eta": {"min": 0.01, "max": 0.3, "log": True},
                     "num_parallel_tree": {"min": 1, "max": 3, "step": 1},
+                    "gamma": {"min": 0.0, "max": 0.5, "step": 0.1},
+                    "reg_alpha": {"min": 1e-10, "max": 1.0, "log": True},
+                    "reg_lambda": {"min": 1e-10, "max": 1.0, "log": True},
+                    "colsample_bytree": {"min": 0.3, "max": 1.0},
                 },
             ),
             (
@@ -303,6 +322,10 @@ class TestStaticSearchSpace(unittest.TestCase):
                     "batch_size": [32, 64, 128, 256],
                     "epochs": [10, 50, 100, 200],
                     "n_units_hl": [32, 64, 128, 256, 512],
+                    "dropout_rate": {"min": 0.0, "max": 0.5, "step": 0.05},
+                    "weight_decay": {"min": 1e-6, "max": 1e-2, "log": True},
+                    "early_stopping_patience": {"min": 2, "max": 10, "step": 1},
+                    "early_stopping_min_delta": {"min": 1e-5, "max": 1e-2, "log": True},
                 },
             ),
         ]

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -213,7 +213,16 @@ class TestTrainables(unittest.TestCase):
     @patch("ritme.model_space.static_trainables._report_results_manually")
     def test_train_rf(self, mock_report, mock_rf, mock_process_train):
         # Arrange
-        config = {"n_estimators": 100, "max_depth": 10}
+        config = {
+            "n_estimators": 100,
+            "max_depth": 10,
+            "min_samples_split": 0.2,
+            "min_weight_fraction_leaf": 0.001,
+            "min_samples_leaf": 0.1,
+            "max_features": "sqrt",
+            "min_impurity_decrease": 0.0,
+            "bootstrap": True,
+        }
 
         mock_process_train.return_value = (None, None, None, None, None)
         mock_rf_instance = mock_rf.return_value
@@ -236,6 +245,12 @@ class TestTrainables(unittest.TestCase):
         mock_rf.assert_called_once_with(
             n_estimators=config["n_estimators"],
             max_depth=config["max_depth"],
+            min_samples_split=config["min_samples_split"],
+            min_weight_fraction_leaf=config["min_weight_fraction_leaf"],
+            min_samples_leaf=config["min_samples_leaf"],
+            max_features=config["max_features"],
+            min_impurity_decrease=config["min_impurity_decrease"],
+            bootstrap=config["bootstrap"],
             n_jobs=None,
             random_state=0,
         )

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -369,6 +369,10 @@ class TestTrainables(unittest.TestCase):
             "n_units_hl1": 5,
             "learning_rate": 0.01,
             "epochs": 5,
+            "dropout_rate": 0.0,
+            "weight_decay": 0.0,
+            "early_stopping_patience": 3,
+            "early_stopping_min_delta": 0.0,
             "checkpoint_dir": "checkpoints",
         }
         train_val = MagicMock()
@@ -396,7 +400,11 @@ class TestTrainables(unittest.TestCase):
         )
         mock_load_data.assert_called()
         mock_neural_net.assert_called_once_with(
-            n_units=nb_units, learning_rate=0.01, nn_type=nn_type
+            n_units=nb_units,
+            learning_rate=0.01,
+            nn_type=nn_type,
+            dropout_rate=0.0,
+            weight_decay=0.0,
         )
         mock_trainer_instance.fit.assert_called()
 
@@ -459,6 +467,10 @@ class TestTrainableLogging(unittest.TestCase):
             "n_hidden_layers": 1,
             "epochs": 2,
             "learning_rate": 0.01,
+            "dropout_rate": 0.0,
+            "weight_decay": 0.0,
+            "early_stopping_patience": 3,
+            "early_stopping_min_delta": 0.0,
         }
         for i in range(search_space["n_hidden_layers"]):
             search_space[f"n_units_hl{i}"] = 2

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -276,7 +276,14 @@ class TestTrainables(unittest.TestCase):
         # Arrange
         config = {
             "max_depth": 6,
+            "min_child_weight": 3,
+            "subsample": 0.9,
             "eta": 0.3,
+            "num_parallel_tree": 2,
+            "gamma": 0.1,
+            "reg_alpha": 0.1,
+            "reg_lambda": 0.1,
+            "colsample_bytree": 0.9,
             "objective": "multi:softprob",
             "num_class": 3,
         }


### PR DESCRIPTION
this PR:
* adds regularisation for XGB and NN
* fixes that large hyperparameter search space defined for RF (beyond `n_estimators` & `max_depth`) is actually used during training of trainable
* adds adjustable sampler for optuna SearchAlgorithm - options include TPESampler, CmaEsSampler, GPSampler, QMCSampler and RandomSampler