### PR TITLE
ENH: static trainables and search spaces

### DIFF
--- a/config/run_config_whparams.json
+++ b/config/run_config_whparams.json
@@ -14,12 +14,14 @@
   "model_hyperparameters": {
     "linreg": {
       "alpha": {
-        "max": 1,
-        "min": 0
+        "log": true,
+        "max": 100,
+        "min": 1e-05
       },
       "l1_ratio": {
         "max": 1,
-        "min": 0
+        "min": 0,
+        "step": 0.1
       }
     },
     "nn_all_types": {

--- a/ritme/evaluate_models.py
+++ b/ritme/evaluate_models.py
@@ -44,7 +44,7 @@ def load_sklearn_model(result: Result) -> Any:
     return load(result.metrics["model_path"])
 
 
-def load_trac_model(result: Result) -> Any:
+def load_trac_model(result: Result) -> dict:
     """
     Load a TRAC model from a given result object.
     """

--- a/ritme/feature_space/_process_trac_specific.py
+++ b/ritme/feature_space/_process_trac_specific.py
@@ -76,7 +76,12 @@ def _create_matrix_for_internal_nodes(num_leaves, internal_nodes, leaf_index_map
             node_leaf_names, tax, a2_node_names, j
         )
         a2_node_names.append(node_consensus_taxon)
-    return A2, a2_node_names
+
+    # remove collinear (duplicated) columns and keep name of the first duplicate
+    A2_df = pd.DataFrame(A2, columns=a2_node_names)
+    A2_df_uni = A2_df.loc[:, ~A2_df.T.duplicated(keep="first")]
+
+    return A2_df_uni.values, A2_df_uni.columns.tolist()
 
 
 def create_matrix_from_tree(tree, tax) -> pd.DataFrame:

--- a/ritme/feature_space/_process_trac_specific.py
+++ b/ritme/feature_space/_process_trac_specific.py
@@ -100,9 +100,11 @@ def create_matrix_from_tree(tree, tax) -> pd.DataFrame:
     df_a = pd.DataFrame(
         A, columns=a1_node_names + a2_node_names, index=[leaf.name for leaf in leaves]
     )
-    _verify_matrix_a(df_a.values, tax.index.tolist(), tree)
+    # transform to sparse matrix for memory efficiency
+    df_a_sparse = df_a.astype(pd.SparseDtype("float", 0))
+    _verify_matrix_a(df_a_sparse.values, tax.index.tolist(), tree)
 
-    return df_a
+    return df_a_sparse
 
 
 def _preprocess_taxonomy_aggregation(x, A):

--- a/ritme/model_space/static_searchspace.py
+++ b/ritme/model_space/static_searchspace.py
@@ -44,13 +44,18 @@ def get_linreg_space(trial, tax, model_hyperparameters: dict = {}) -> Dict[str, 
     get_data_eng_space(trial, tax)
 
     # alpha controls overall regularization strength, alpha = 0 is equivalent to
-    # an ordinary least square. large alpha -> more regularization
-    alpha = model_hyperparameters.get("alpha", {"min": 0, "max": 1})
-    trial.suggest_float("alpha", alpha["min"], alpha["max"])
+    # an ordinary least square - but = 0 is not numerically reliable. large
+    # alpha -> more regularization
+    alpha = model_hyperparameters.get(
+        "alpha", {"min": 0.00001, "max": 100, "log": True}
+    )
+    trial.suggest_float("alpha", alpha["min"], alpha["max"], log=alpha["log"])
 
     # balance between L1 and L2 reg., when =0 -> L2, when =1 -> L1
-    l1_ratio = model_hyperparameters.get("l1_ratio", {"min": 0, "max": 1})
-    trial.suggest_float("l1_ratio", l1_ratio["min"], l1_ratio["max"])
+    l1_ratio = model_hyperparameters.get("l1_ratio", {"min": 0, "max": 1, "step": 0.1})
+    trial.suggest_float(
+        "l1_ratio", l1_ratio["min"], l1_ratio["max"], step=l1_ratio["step"]
+    )
 
     return {"model": "linreg"}
 

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -186,7 +186,7 @@ def _bundle_trac_model(alpha, A_df):
 def _report_results_manually_trac(
     model, log_geom_train, y_train, log_geom_val, y_val, tax
 ):
-    # save model
+    # save model in a compressed way
     path_to_save = ray.train.get_context().get_trial_dir()
     model_path = os.path.join(path_to_save, "model.pkl")
     with open(model_path, "wb") as file:
@@ -244,6 +244,7 @@ def train_trac(
         config, train_val, target, host_id, tax, seed_data
     )
     # ! derive matrix A
+    # todo: adjust A_df here already
     a_df = create_matrix_from_tree(tree_phylo, tax)
 
     # ! get log_geom

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -26,6 +26,8 @@ from sklearn.base import BaseEstimator
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import ElasticNet
 from sklearn.metrics import r2_score, root_mean_squared_error
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from torch import nn
 from torch.optim import Adam
 from torch.utils.data import DataLoader, TensorDataset
@@ -149,10 +151,18 @@ def train_linreg(
 
     # ! model
     np.random.seed(seed_model)
-    linreg = ElasticNet(
-        alpha=config["alpha"],
-        l1_ratio=config["l1_ratio"],
-        fit_intercept=True,
+    linreg = Pipeline(
+        [
+            ("scaler", StandardScaler()),
+            (
+                "linreg",
+                ElasticNet(
+                    alpha=config["alpha"],
+                    l1_ratio=config["l1_ratio"],
+                    fit_intercept=True,
+                ),
+            ),
+        ]
     )
     linreg.fit(X_train, y_train)
 

--- a/ritme/tests/test_feature_space.py
+++ b/ritme/tests/test_feature_space.py
@@ -712,6 +712,7 @@ class TestProcessTracSpecific(unittest.TestCase):
             columns=leaf_names + node_taxon_names,
             index=ft_names,
         )
+        ma_exp = ma_exp.astype(pd.SparseDtype("float", 0))
         ma_act = create_matrix_from_tree(self.tree, self.tax)
 
         assert_frame_equal(ma_exp, ma_act)

--- a/ritme/tests/test_feature_space.py
+++ b/ritme/tests/test_feature_space.py
@@ -657,6 +657,30 @@ class TestProcessTracSpecific(unittest.TestCase):
 
         return tree
 
+    def _build_collinear_example_tree(self):
+        # Create the tree nodes with lengths
+        n1 = TreeNode(name="node1")
+        f1 = TreeNode(name="F1", length=1.0)
+        f2 = TreeNode(name="F2", length=1.0)
+        n2 = TreeNode(name="node2")
+        f3 = TreeNode(name="F3", length=1.0)
+        n3 = TreeNode(name="node3")
+        n4 = TreeNode(name="node4")
+
+        # Build the tree structure with lengths
+        n1.extend([f1, f2])
+        n2.extend([f3])
+        n3.extend([n2])
+        n4.extend([n1, n3])
+        n1.length = 1.0
+        n2.length = 1.0
+        n3.length = 1.0
+        n4.length = 1.0
+
+        tree = n4
+
+        return tree
+
     def test_get_leaves_and_index_map(self):
         leaves, leaf_index_map = _get_leaves_and_index_map(self.tree)
         self.assertEqual(len(leaves), 3)
@@ -694,6 +718,25 @@ class TestProcessTracSpecific(unittest.TestCase):
             [
                 "d__Bacteria; p__Chloroflexi; c__Anaerolineae; o__SBR1031; "
                 "f__SBR1031; g__SBR1031"
+            ],
+        )
+
+    def test_create_matrix_for_internal_nodes_collinear_cols(self):
+        """Tests that collinear columns are collapsed"""
+        tree_collinear = self._build_collinear_example_tree()
+        leaves, leaf_index_map = _get_leaves_and_index_map(tree_collinear)
+        internal_nodes = _get_internal_nodes(tree_collinear)
+
+        A2, a2_node_names = _create_matrix_for_internal_nodes(
+            3, internal_nodes, leaf_index_map, self.tax
+        )
+        np.testing.assert_array_equal(A2, np.array([[1, 0], [1, 0], [0, 1]]))
+        self.assertEqual(
+            a2_node_names,
+            [
+                "d__Bacteria; p__Chloroflexi; c__Anaerolineae; o__SBR1031; "
+                "f__SBR1031; g__SBR1031",
+                "d__Bacteria; p__Chloroflexi; c__Anaerolineae; o__SBR1031",
             ],
         )
 

--- a/ritme/tests/test_model_static_searchspace.py
+++ b/ritme/tests/test_model_static_searchspace.py
@@ -1,34 +1,47 @@
+import datetime
 import unittest
-from unittest.mock import patch
+import unittest.mock as mock
 
 import pandas as pd
+from optuna.trial import FrozenTrial
+from optuna.trial._state import TrialState
+from optuna.trial._trial import Trial
 from parameterized import parameterized
 
 from ritme.model_space import static_searchspace as ss
 
 
-class MockTrial:
+class MockTrial(Trial):
     def __init__(self):
-        self.params = {}
-
-    def suggest_categorical(self, name, categories):
-        self.params[name] = categories[0] if categories else None
-        return self.params[name]
-
-    def suggest_int(self, name, low, high, step=1):
-        self.params[name] = low
-        return low
-
-    def suggest_float(self, name, low, high, step=None, log=False):
-        self.params[name] = low
-        return low
+        self._study = mock.MagicMock()
+        self._study._storage = mock.MagicMock()
+        real_frozen_trial = FrozenTrial(
+            number=1,
+            trial_id=1,
+            state=TrialState.RUNNING,
+            value=None,
+            values=None,
+            datetime_start=datetime.datetime.now(),
+            datetime_complete=None,
+            params={},
+            distributions={},
+            user_attrs={},
+            system_attrs={},
+            intermediate_values={},
+        )
+        self._study._storage.get_trial.return_value = real_frozen_trial
+        super().__init__(study=self._study, trial_id=1)
 
 
 class TestStaticSearchSpace(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.tax = pd.DataFrame()
-        self.data_params_prefix = "data_"
+        self.model_independent_params = {
+            "data_aggregation": "tax_class",
+            "data_selection": None,
+            "data_transform": "clr",
+        }
 
     @parameterized.expand(
         [
@@ -45,45 +58,6 @@ class TestStaticSearchSpace(unittest.TestCase):
         self.assertIn(hyperparam, trial.params)
         self.assertIsNotNone(trial.params[hyperparam])
 
-    def test_get_data_eng_space(self):
-        trial = MockTrial()
-        ss.get_data_eng_space(trial, self.tax)
-        expected_params = {"data_selection", "data_aggregation", "data_transform"}
-        self.assertTrue(expected_params.issubset(trial.params.keys()))
-
-    def test_get_linreg_space(self):
-        trial = MockTrial()
-        linreg_space = ss.get_linreg_space(trial, self.tax)
-        self.assertIsInstance(linreg_space, dict)
-        self.assertEqual(linreg_space["model"], "linreg")
-
-        trial_model_params = {
-            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
-        }
-        expected_params = {"alpha", "l1_ratio"}
-        self.assertSetEqual(trial_model_params, expected_params)
-
-    def test_get_rf_space(self):
-        trial = MockTrial()
-        rf_space = ss.get_rf_space(trial, self.tax)
-        self.assertIsInstance(rf_space, dict)
-        self.assertEqual(rf_space["model"], "rf")
-
-        trial_model_params = {
-            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
-        }
-        expected_params = {
-            "n_estimators",
-            "max_depth",
-            "min_samples_split",
-            "min_weight_fraction_leaf",
-            "min_samples_leaf",
-            "max_features",
-            "min_impurity_decrease",
-            "bootstrap",
-        }
-        self.assertSetEqual(trial_model_params, expected_params)
-
     @parameterized.expand(
         [
             ("nn_reg",),
@@ -92,50 +66,32 @@ class TestStaticSearchSpace(unittest.TestCase):
         ]
     )
     def test_get_nn_space(self, model_type):
+        exp_model_params = {
+            "n_hidden_layers": 2,
+            "learning_rate": 0.001,
+            "batch_size": 64,
+            "epochs": 100,
+            "n_units_hl0": 64,
+            "n_units_hl1": 128,
+            "dropout_rate": 0.1,
+            "weight_decay": 0.0001,
+            "early_stopping_patience": 5,
+            "early_stopping_min_delta": 1e-4,
+        }
+        # init
         trial = MockTrial()
+        trial._study.sampler.sample_independent.side_effect = list(
+            self.model_independent_params.values()
+        ) + list(exp_model_params.values())
+        # call
         nn_space = ss.get_nn_space(trial, self.tax, model_type)
 
+        # assert
         self.assertIsInstance(nn_space, dict)
         self.assertEqual(nn_space["model"], model_type)
 
-        trial_model_params = {
-            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
-        }
-        expected_params = {
-            "n_hidden_layers",
-            "learning_rate",
-            "batch_size",
-            "epochs",
-            "dropout_rate",
-            "weight_decay",
-            "early_stopping_patience",
-            "early_stopping_min_delta",
-        }.union({f"n_units_hl{i}" for i in range(5)})
-        self.assertSetEqual(trial_model_params, expected_params)
-
-        self.assertTrue(any(f"n_units_hl{i}" in trial.params for i in range(30)))
-
-    def test_get_xgb_space(self):
-        trial = MockTrial()
-        xgb_space = ss.get_xgb_space(trial, self.tax)
-        self.assertIsInstance(xgb_space, dict)
-        self.assertEqual(xgb_space["model"], "xgb")
-
-        trial_model_params = {
-            k for k in trial.params.keys() if not k.startswith(self.data_params_prefix)
-        }
-        expected_params = {
-            "max_depth",
-            "min_child_weight",
-            "subsample",
-            "eta",
-            "num_parallel_tree",
-            "gamma",
-            "reg_alpha",
-            "reg_lambda",
-            "colsample_bytree",
-        }
-        self.assertSetEqual(trial_model_params, expected_params)
+        expected_params = {**exp_model_params, **self.model_independent_params}
+        self.assertDictEqual(trial.params, expected_params)
 
     def test_get_trac_space(self):
         trial = MockTrial()
@@ -143,6 +99,57 @@ class TestStaticSearchSpace(unittest.TestCase):
         self.assertIsInstance(trac_space, dict)
         self.assertEqual(trac_space["model"], "trac")
         self.assertIn("lambda", trial.params)
+
+    @parameterized.expand(
+        [
+            ("linreg", ss.get_linreg_space, {"alpha": 0.001, "l1_ratio": 0.2}),
+            (
+                "rf",
+                ss.get_rf_space,
+                {
+                    "n_estimators": 100,
+                    "max_depth": 16,
+                    "min_samples_split": 0.01,
+                    "min_weight_fraction_leaf": 0.0,
+                    "min_samples_leaf": 0.01,
+                    "max_features": "sqrt",
+                    "min_impurity_decrease": 0.1,
+                    "bootstrap": True,
+                },
+            ),
+            (
+                "xgb",
+                ss.get_xgb_space,
+                {
+                    "max_depth": 6,
+                    "min_child_weight": 2,
+                    "subsample": 0.9,
+                    "eta": 0.05,
+                    "num_parallel_tree": 2,
+                    "gamma": 0.1,
+                    "reg_alpha": 0.2,
+                    "reg_lambda": 0.5,
+                    "colsample_bytree": 0.7,
+                },
+            ),
+        ]
+    )
+    def test_get_others_space(self, model_name, func_get_space, exp_model_params):
+        # init
+        trial = MockTrial()
+        trial._study.sampler.sample_independent.side_effect = list(
+            self.model_independent_params.values()
+        ) + list(exp_model_params.values())
+
+        # call
+        model_space = func_get_space(trial, self.tax)
+
+        # assert
+        self.assertIsInstance(model_space, dict)
+        self.assertEqual(model_space["model"], model_name)
+
+        expected_params = {**exp_model_params, **self.model_independent_params}
+        self.assertDictEqual(trial.params, expected_params)
 
     @parameterized.expand(
         [
@@ -156,7 +163,11 @@ class TestStaticSearchSpace(unittest.TestCase):
         ]
     )
     def test_get_search_space(self, model_type):
-        trial = MockTrial()
+        trial = mock.Mock(
+            suggest_categorical=mock.MagicMock(),
+            suggest_int=mock.MagicMock(),
+            suggest_float=mock.MagicMock(),
+        )
         search_space = ss.get_search_space(trial, model_type, self.tax)
         self.assertIsInstance(search_space, dict)
         self.assertEqual(search_space["model"], model_type)
@@ -167,120 +178,59 @@ class TestStaticSearchSpace(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Model type FakeModel not supported."):
             ss.get_search_space(trial, model_type, self.tax)
 
-    @parameterized.expand(
-        [
-            (
-                "linreg",
-                {
-                    "alpha": {"min": 0.1, "max": 0.9},
-                    "l1_ratio": {"min": 0.2, "max": 0.8},
-                },
-            ),
-            (
-                "rf",
-                {
-                    "n_estimators": {"min": 50, "max": 150, "step": 10},
-                    "max_depth": [5, 10, 15, None],
-                    "min_samples_split": {"min": 0.01, "max": 0.05, "log": True},
-                    "min_weight_fraction_leaf": {
-                        "min": 0.0005,
-                        "max": 0.005,
-                        "log": True,
-                    },
-                    "min_samples_leaf": {"min": 0.01, "max": 0.05, "log": True},
-                    "max_features": [None, "sqrt", "log2", 0.2],
-                    "min_impurity_decrease": {"min": 0.01, "max": 0.1, "log": True},
-                    "bootstrap": [True, False],
-                },
-            ),
-            (
-                "xgb",
-                {
-                    "max_depth": {"min": 3, "max": 7},
-                    "min_child_weight": {"min": 1, "max": 3},
-                    "subsample": {"min": 0.8, "max": 1.0},
-                    "eta": {"min": 0.05, "max": 0.2, "log": True},
-                    "num_parallel_tree": {"min": 2, "max": 4, "step": 1},
-                    "gamma": {"min": 0.1, "max": 3.0, "step": 0.1},
-                    "reg_alpha": {"min": 0.1, "max": 0.5, "log": True},
-                    "reg_lambda": {"min": 0.1, "max": 0.5, "log": True},
-                    "colsample_bytree": {"min": 0.7, "max": 0.8},
-                },
-            ),
-            (
-                "nn_reg",
-                {
-                    "n_hidden_layers": {"min": 2, "max": 10, "step": 2},
-                    "learning_rate": [0.01, 0.001, 0.0001],
-                    "batch_size": [64, 128],
-                    "epochs": [50, 100],
-                    "n_units_hl": [64, 128, 256],
-                    "dropout_rate": {"min": 0.1, "max": 0.3},
-                    "weight_decay": {"min": 0.0001, "max": 0.001, "log": True},
-                    "early_stopping_patience": {"min": 5, "max": 20, "step": 5},
-                    "early_stopping_min_delta": {
-                        "min": 0.001,
-                        "max": 0.01,
-                        "log": True,
-                    },
-                },
-            ),
-        ]
-    )
-    @patch("ritme.model_space.static_searchspace.get_search_space")
-    def test_hyperparameter_passing_different_than_default(
-        self, model_type, hyperparameters, mock_get_search_space
-    ):
-        trial = MockTrial()
-        ss.get_search_space(
-            trial,
-            model_type,
-            self.tax,
-            model_hyperparameters=hyperparameters,
-        )
+    def _list_mocked_params_as_calls(self, exp_defaults):
+        mocked_params = []
+        for param_name, param_config in exp_defaults.items():
+            if "log" in param_config:
+                # suggest_float or int
+                mocked_params.append(
+                    mock.call(
+                        param_name,
+                        param_config["min"],
+                        param_config["max"],
+                        log=param_config["log"],
+                    )
+                )
+            elif "step" in param_config:
+                # suggest_float or int
+                mocked_params.append(
+                    mock.call(
+                        param_name,
+                        param_config["min"],
+                        param_config["max"],
+                        step=param_config["step"],
+                    )
+                )
+            elif type(param_config) is list:
+                # suggest_categorical
 
-        # Verify that the get_search_space function was called with the correct
-        # hyperparameters
-        mock_get_search_space.assert_called_once_with(
-            trial,
-            model_type,
-            self.tax,
-            model_hyperparameters=hyperparameters,
-        )
-
-    def _verify_trial_params(self, trial, expected_defaults):
-        for param, config in expected_defaults.items():
-            if param == "n_units_hl":
-                self._verify_n_units_hl(trial, config)
+                # special case for NN hyperparameters
+                i = 0
+                if param_name == "n_units_hl":
+                    param_name = f"n_units_hl{i}"
+                    i += 1
+                mocked_params.append(mock.call(param_name, param_config))
             else:
-                self._verify_param(trial, param, config)
-
-    def _verify_param(self, trial, param, config):
-        self.assertIn(param, trial.params)
-        if isinstance(config, dict):
-            self.assertGreaterEqual(trial.params[param], config["min"])
-            self.assertLessEqual(trial.params[param], config["max"])
-        else:
-            self.assertIn(trial.params[param], config)
-
-    def _verify_n_units_hl(self, trial, config):
-        n_hidden_layers_selected = trial.params["n_hidden_layers"]
-        for i in range(n_hidden_layers_selected):
-            param_name = f"n_units_hl{i}"
-            self.assertIn(param_name, trial.params)
-            self.assertIn(trial.params[param_name], config)
+                # suggest_float or int
+                mocked_params.append(
+                    mock.call(param_name, param_config["min"], param_config["max"])
+                )
+        return mocked_params
 
     @parameterized.expand(
         [
             (
                 "linreg",
-                {"alpha": {"min": 0, "max": 1}, "l1_ratio": {"min": 0, "max": 1}},
+                {
+                    "alpha": {"min": 0.00001, "max": 100, "log": True},
+                    "l1_ratio": {"min": 0, "max": 1, "step": 0.1},
+                },
+                {},
+                {},
             ),
             (
                 "rf",
                 {
-                    "n_estimators": {"min": 40, "max": 200, "step": 20},
-                    "max_depth": [4, 8, 16, 32, None],
                     "min_samples_split": {"min": 0.001, "max": 0.1, "log": True},
                     "min_weight_fraction_leaf": {
                         "min": 0.0,
@@ -288,29 +238,44 @@ class TestStaticSearchSpace(unittest.TestCase):
                         "log": False,
                     },
                     "min_samples_leaf": {"min": 0.001, "max": 0.1, "log": True},
-                    "max_features": [None, "sqrt", "log2", 0.1, 0.2, 0.3, 0.5],
                     "min_impurity_decrease": {"min": 0.0, "max": 0.5, "log": False},
+                },
+                {"n_estimators": {"min": 40, "max": 200, "step": 20}},
+                {
+                    "max_depth": [4, 8, 16, 32, None],
+                    "max_features": [None, "sqrt", "log2", 0.1, 0.2, 0.3, 0.5],
                     "bootstrap": [True, False],
                 },
             ),
             (
                 "xgb",
                 {
-                    "max_depth": {"min": 2, "max": 10},
-                    "min_child_weight": {"min": 0, "max": 4},
                     "subsample": {"min": 0.7, "max": 1.0},
                     "eta": {"min": 0.01, "max": 0.3, "log": True},
-                    "num_parallel_tree": {"min": 1, "max": 3, "step": 1},
-                    "gamma": {"min": 0.0, "max": 0.5, "step": 0.1},
+                    "gamma": {"min": 0.0, "max": 5.0, "step": 0.1},
                     "reg_alpha": {"min": 1e-10, "max": 1.0, "log": True},
                     "reg_lambda": {"min": 1e-10, "max": 1.0, "log": True},
                     "colsample_bytree": {"min": 0.3, "max": 1.0},
                 },
+                {
+                    "max_depth": {"min": 2, "max": 10},
+                    "min_child_weight": {"min": 0, "max": 4},
+                    "num_parallel_tree": {"min": 1, "max": 3, "step": 1},
+                },
+                {},
             ),
             (
                 "nn_reg",
                 {
-                    "n_hidden_layers": {"min": 1, "max": 30, "step": 5},
+                    "dropout_rate": {"min": 0.0, "max": 0.5, "step": 0.05},
+                    "weight_decay": {"min": 1e-6, "max": 1e-2, "log": True},
+                    "early_stopping_min_delta": {"min": 1e-5, "max": 1e-2, "log": True},
+                },
+                {
+                    "n_hidden_layers": {"min": 5, "max": 30, "step": 5},
+                    "early_stopping_patience": {"min": 2, "max": 10, "step": 1},
+                },
+                {
                     "learning_rate": [
                         0.01,
                         0.005,
@@ -322,21 +287,134 @@ class TestStaticSearchSpace(unittest.TestCase):
                     ],
                     "batch_size": [32, 64, 128, 256],
                     "epochs": [10, 50, 100, 200],
-                    "n_units_hl": [32, 64, 128, 256, 512],
-                    "dropout_rate": {"min": 0.0, "max": 0.5, "step": 0.05},
-                    "weight_decay": {"min": 1e-6, "max": 1e-2, "log": True},
-                    "early_stopping_patience": {"min": 2, "max": 10, "step": 1},
-                    "early_stopping_min_delta": {"min": 1e-5, "max": 1e-2, "log": True},
+                    "n_units_hl0": [32, 64, 128, 256, 512],
+                    "n_units_hl1": [32, 64, 128, 256, 512],
                 },
             ),
         ]
     )
-    def test_hyperparameter_default_used(self, model_type, expected_defaults):
+    def test_hyperparameter_default_used(self, model_type, exp_float, exp_int, exp_cat):
         """Verifies that the default hyperparameters are used when not passed."""
-        trial = MockTrial()
+        trial = mock.Mock(
+            suggest_categorical=mock.MagicMock(),
+            suggest_int=mock.MagicMock(),
+            suggest_float=mock.MagicMock(),
+        )
+        # if NN return n_hidden_layers = 2
+        if model_type in ["nn_reg", "nn_class", "nn_corn"]:
+            trial.suggest_int.side_effect = [2, 100, 100]
 
         # Call the actual function without passing model_hyperparameters
         _ = ss.get_search_space(trial, model_type, self.tax)
 
         # Verify that the trial parameters match the expected defaults
-        self._verify_trial_params(trial, expected_defaults)
+        if len(exp_float) > 0:
+            mocked_params_float = self._list_mocked_params_as_calls(exp_float)
+            trial.suggest_float.assert_has_calls(mocked_params_float)
+        if len(exp_int) > 0:
+            mocked_params_int = self._list_mocked_params_as_calls(exp_int)
+            trial.suggest_int.assert_has_calls(mocked_params_int)
+        if len(exp_cat) > 0:
+            mocked_params_cat = self._list_mocked_params_as_calls(exp_cat)
+            trial.suggest_categorical.assert_has_calls(mocked_params_cat)
+
+    @parameterized.expand(
+        [
+            (
+                "linreg",
+                {
+                    "alpha": {"min": 0.05, "max": 1, "log": True},
+                    "l1_ratio": {"min": 0.2, "max": 0.5, "step": 0.1},
+                },
+                {},
+                {},
+            ),
+            (
+                "rf",
+                {
+                    "min_samples_split": {"min": 0.01, "max": 0.05, "log": True},
+                    "min_weight_fraction_leaf": {
+                        "min": 0.0005,
+                        "max": 0.005,
+                        "log": True,
+                    },
+                    "min_samples_leaf": {"min": 0.01, "max": 0.05, "log": True},
+                    "min_impurity_decrease": {"min": 0.01, "max": 0.1, "log": True},
+                },
+                {"n_estimators": {"min": 50, "max": 150, "step": 10}},
+                {
+                    "max_depth": [5, 10, 15, None],
+                    "max_features": [None, "sqrt", "log2", 0.2],
+                    "bootstrap": [True],
+                },
+            ),
+            (
+                "xgb",
+                {
+                    "subsample": {"min": 0.8, "max": 1.0},
+                    "eta": {"min": 0.05, "max": 0.2, "log": True},
+                    "gamma": {"min": 0.1, "max": 3.0, "step": 0.1},
+                    "reg_alpha": {"min": 0.1, "max": 0.5, "log": True},
+                    "reg_lambda": {"min": 0.1, "max": 0.5, "log": True},
+                    "colsample_bytree": {"min": 0.7, "max": 0.8},
+                },
+                {
+                    "max_depth": {"min": 3, "max": 7},
+                    "min_child_weight": {"min": 1, "max": 3},
+                    "num_parallel_tree": {"min": 2, "max": 4, "step": 1},
+                },
+                {},
+            ),
+            (
+                "nn_reg",
+                {
+                    "dropout_rate": {"min": 0.1, "max": 0.3, "step": 0.1},
+                    "weight_decay": {"min": 0.0001, "max": 0.001, "log": True},
+                    "early_stopping_min_delta": {
+                        "min": 0.001,
+                        "max": 0.01,
+                        "log": True,
+                    },
+                },
+                {
+                    "n_hidden_layers": {"min": 2, "max": 10, "step": 2},
+                    "early_stopping_patience": {"min": 5, "max": 20, "step": 5},
+                },
+                {
+                    "learning_rate": [0.01, 0.001, 0.0001],
+                    "batch_size": [64, 128],
+                    "epochs": [2],
+                    "n_units_hl": [32, 64],
+                },
+            ),
+        ]
+    )
+    def test_hyperparameter_passing_different_than_default(
+        self, model_type, exp_float, exp_int, exp_cat
+    ):
+        """Verifies that custom hyperparameters are used when passed."""
+        trial = mock.Mock(
+            suggest_categorical=mock.MagicMock(),
+            suggest_int=mock.MagicMock(),
+            suggest_float=mock.MagicMock(),
+        )
+        # if NN return n_hidden_layers = 2
+        if model_type in ["nn_reg", "nn_class", "nn_corn"]:
+            trial.suggest_int.side_effect = [2, 2, 2]
+
+        # Call the actual function with passing model_hyperparameters
+        exp_params = {**exp_float, **exp_int, **exp_cat}
+        _ = ss.get_search_space(
+            trial, model_type, self.tax, model_hyperparameters=exp_params
+        )
+
+        # Verify that the trial parameters match the expected defaults
+        if len(exp_float) > 0:
+            mocked_params_float = self._list_mocked_params_as_calls(exp_float)
+            trial.suggest_float.assert_has_calls(mocked_params_float)
+        if len(exp_int) > 0:
+            mocked_params_int = self._list_mocked_params_as_calls(exp_int)
+            trial.suggest_int.assert_has_calls(mocked_params_int)
+        if len(exp_cat) > 0:
+            mocked_params_cat = self._list_mocked_params_as_calls(exp_cat)
+            trial.suggest_categorical.assert_has_calls(mocked_params_cat)


### PR DESCRIPTION
this PR:
* for **LinReg**: adds scaling before LinReg + improves search space
* for **trac**: improves storage of model + drops collinear columns in matrix A
* fixes unit tests of **all** trainable search spaces to correctly check parameters