### PR TITLE
FIX: Ray dependency

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -38,8 +38,8 @@ requirements:
     - qiime2::qiime2
     - qiime2::q2-feature-table
     - qiime2::q2-phylogeny
-    - conda-forge::ray-default
-    - conda-forge::ray-tune
+    - conda-forge::ray-default>=2.40.0
+    - conda-forge::ray-tune>=2.40.0
     - scikit-bio
     - scikit-learn
     - scipy


### PR DESCRIPTION
this PR ensures that ray dependencies can not be installed from outdated (anaconda) channel instead of conda-forge - hopefully even on HPCs