### PR TITLE
FIX: trainables nn_corn + trac

### DIFF
--- a/ritme/evaluate_tuned_models.py
+++ b/ritme/evaluate_tuned_models.py
@@ -55,9 +55,10 @@ def _calculate_metrics(all_preds: pd.DataFrame, model_type: str) -> pd.DataFrame
         metrics.loc[model_type, f"r2_{split}"] = r2_score(
             pred_split["true"], pred_split["pred"]
         )
-        metrics.loc[model_type, f"pearson_corr_{split}"] = pearsonr(
-            pred_split["true"].astype(float), pred_split["pred"]
-        )[0]
+        pearson_results = pearsonr(pred_split["true"].astype(float), pred_split["pred"])
+        metrics.loc[model_type, f"pearson_corr_{split}"] = pearson_results[0]
+        # two-sided alternative
+        metrics.loc[model_type, f"pearson_corr_{split}_pvalue"] = pearson_results[1]
     return metrics
 
 
@@ -127,15 +128,16 @@ def _plot_scatter_plots(
         lims = [min(x0, y0), max(x1, y1)]
         reg.axes.plot(lims, lims, ":k")
 
-        # add rmse and r2 metrics to plot
+        # add rmse, r2 and pearson corr metrics to plot
         rmse = metrics_split[f"rmse_{split}"].values[0]
         r2 = metrics_split[f"r2_{split}"].values[0]
+        r = metrics_split[f"pearson_corr_{split}"].values[0]
 
         trans = offset_copy(axs_set.transData, x=1, y=-1, units="dots")
         axs_set.text(
             lims[0],
             lims[1],
-            f"RMSE: {rmse:.2f}\nR²: {r2:.2f}",
+            f"RMSE: {rmse:.2f}\nR²: {r2:.2f}\nR: {r:.2f}",
             transform=trans,
             color=colors[split],
             ha="left",

--- a/ritme/tests/test_evaluate_tuned_models.py
+++ b/ritme/tests/test_evaluate_tuned_models.py
@@ -43,9 +43,11 @@ class TestEvaluateTunedModels(unittest.TestCase):
                 "rmse_train": [0.1],
                 "r2_train": [0.985],
                 "pearson_corr_train": [1.0],
+                "pearson_corr_train_pvalue": [1.341576e-08],
                 "rmse_test": [0.1],
                 "r2_test": [0.96],
                 "pearson_corr_test": [1.0],
+                "pearson_corr_test_pvalue": [1.0],
             },
             index=[self.model_type],
         )

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -338,7 +338,7 @@ class TestTrainables(unittest.TestCase):
         [
             ("regression", [5, 10, 5, 1], None),
             ("classification", [5, 10, 5, 3], [0, 1, 2]),
-            ("ordinal_regression", [5, 10, 5, 2], None),
+            ("ordinal_regression", [5, 10, 5, 2], [0, 1, 2]),
         ]
     )
     @patch("ritme.model_space.static_trainables._save_taxonomy")

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -378,6 +378,16 @@ def run_all_trials(
             "data_enrich_with", None
         )
 
+        # reduce number of concurrent trials in case of trac - requires too much memory
+        if model == "trac":
+            # todo: implement trac to reduce memory usage
+            max_concurrent_trials_launched = max(1, round(max_concurrent_trials / 3))
+            print(
+                f"Reducing max_concurrent_trials to {max_concurrent_trials_launched} "
+                "for trac model due to high memory requirements."
+            )
+        else:
+            max_concurrent_trials_launched = max_concurrent_trials
         result = run_trials(
             mlflow_uri,
             model,
@@ -391,7 +401,7 @@ def run_all_trials(
             tree_phylo,
             path_exp,
             num_trials,
-            max_concurrent_trials,
+            max_concurrent_trials_launched,
             fully_reproducible=fully_reproducible,
             model_hyperparameters=model_hparams_type,
             optuna_searchspace_sampler=optuna_searchspace_sampler,


### PR DESCRIPTION
this PR:
* fixes trainable nn_corn to be launched with class labels instead of actual class values
* reduces concurrent trials launched in case of trac trainable due to high memory requirements with large feature space
* adds more pearson correlation insights to evaluation (scatter + p-value stored)