### PR TITLE
FIX: trainables xgb, nn_corn + nn_class

### DIFF
--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -61,6 +61,11 @@
         "# path to MLflow logs\n",
         "log_folder_location = \"ritme_example_logs/trials_mlflow/mlruns\"\n",
         "\n",
+        "# whether to display all trials (top_n=None) or just top N trials\n",
+        "top_n = None\n",
+        "\n",
+        "# static or dynamic plots (static_plots=False) if available?\n",
+        "static_plots = True\n",
         "######## END USER INPUTS #####"
       ]
     },
@@ -161,7 +166,7 @@
         "    group_col=\"params.model\",\n",
         "    group_name=\"Model type\",\n",
         "    display_trial_name=True,  # if true display trial name on the x-axis\n",
-        "    top_n=None,  # to plot top N models, set to an integer value\n",
+        "    top_n=top_n,  # to plot top N models, set to an integer value\n",
         ")"
       ]
     },
@@ -186,7 +191,7 @@
         "    metric_name=\"RMSE Validation\",\n",
         "    group_col=\"params.model\",\n",
         "    group_name=\"Model type\",\n",
-        "    static=True,  # Set to False for interactive plotly graph\n",
+        "    static=static_plots,  # Set to False for interactive plotly graph\n",
         ")"
       ]
     },
@@ -251,7 +256,7 @@
         "    group_col=var,\n",
         "    group_name=var_name,\n",
         "    display_trial_name=True,  # if true display trial name on the x-axis\n",
-        "    top_n=None,  # to plot top N models, set to an integer value\n",
+        "    top_n=top_n,  # to plot top N models, set to an integer value\n",
         ")"
       ]
     },
@@ -306,7 +311,7 @@
         "    group_col=var,\n",
         "    group_name=var_name,\n",
         "    display_trial_name=True,  # if true display trial name on the x-axis\n",
-        "    top_n=None,  # to plot top N models, set to an integer value\n",
+        "    top_n=top_n,  # to plot top N models, set to an integer value\n",
         ")"
       ]
     },
@@ -361,7 +366,7 @@
         "    group_col=var,\n",
         "    group_name=var_name,\n",
         "    display_trial_name=True,  # if true display trial name on the x-axis\n",
-        "    top_n=None,  # to plot top N models, set to an integer value\n",
+        "    top_n=top_n,  # to plot top N models, set to an integer value\n",
         ")"
       ]
     },
@@ -416,7 +421,7 @@
         "    group_col=var,\n",
         "    group_name=var_name,\n",
         "    display_trial_name=True,  # if true display trial name on the x-axis\n",
-        "    top_n=None,  # to plot top N models, set to an integer value\n",
+        "    top_n=top_n,  # to plot top N models, set to an integer value\n",
         ")"
       ]
     },
@@ -464,6 +469,20 @@
         "metric = \"rmse_train\"\n",
         "client = mlflow.tracking.MlflowClient(tracking_uri=log_folder_location)\n",
         "\n",
+        "# one figure per model type\n",
+        "for model_type in all_trials[\"params.model\"].unique():\n",
+        "    model_trials = all_trials[all_trials[\"params.model\"] == model_type]\n",
+        "    plot_metric_history_per_model_type(metric, client, model_trials)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "64e19ead",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# plot all metric history in one plot\n",
         "plot_metric_history_per_model_type(metric, client, all_trials)"
       ]
     },

--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -491,7 +491,8 @@
       "id": "44980550",
       "metadata": {},
       "source": [
-        "* If per model type later launched trials yield smaller RMSE train then the selected search algorithm works"
+        "* If per model type later launched trials yield smaller RMSE train then the selected search algorithm works\n",
+        "* *Note:* The classification network (`nn_class`) is trained by minimizing the cross\u2010entropy loss, and the ordinal\u2010regression variant (`nn_corn`) is trained by minimizing the CORN loss.  herefore, training curves based on MSE\u2010derived metrics (e.g. RMSE) are not guaranteed to decrease monotonically during optimization for these models."
       ]
     },
     {

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -794,15 +794,16 @@ def train_xgb(
     checkpoint_callback = xgb_cc(
         # tune:xgboost
         metrics={
-            "rmse_train": "train-rmse",
-            "rmse_val": "val-rmse",
             "r2_train": "train-r2",
             "r2_val": "val-r2",
+            "rmse_train": "train-rmse",
+            "rmse_val": "val-rmse",
         },
         filename="checkpoint",
         results_postprocessing_fn=lambda results: add_nb_features_to_results(
             results, X_train.shape[1]
         ),
+        frequency=1,  # Save checkpoint every iteration
     )
     patience = max(10, int(0.1 * config["n_estimators"]))
     xgb.train(

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -599,9 +599,16 @@ def train_nn(
         classes = None
     else:
         # nn_type == "classification" or nn_type == "ordinal_regression"
-        classes_train = np.unique(np.round(y_train).astype(int))
-        classes_val = np.unique(np.round(y_val).astype(int))
+
+        # this rounds the targets in a the torch-way for consistency (np rounds
+        # differently)
+        y_tr_t = torch.from_numpy(y_train).float()
+        y_val_t = torch.from_numpy(y_val).float()
+
+        classes_train = torch.round(y_tr_t).long().unique().cpu().numpy()
+        classes_val = torch.round(y_val_t).long().unique().cpu().numpy()
         classes = sorted(set(classes_train) | set(classes_val))
+
         if nn_type == "classification":
             output_layer = [len(classes)]
         else:  # nn_type == "ordinal_regression"

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -735,7 +735,7 @@ def custom_xgb_metric(
     List[Tuple[str, float]]: List of tuples containing metric names and values.
     """
     y = dtrain.get_label()
-    return [("rmse", np.sqrt(np.mean((predt - y) ** 2))), ("r2", r2_score(y, predt))]
+    return [("r2", r2_score(y, predt)), ("rmse", np.sqrt(np.mean((predt - y) ** 2)))]
 
 
 def train_xgb(
@@ -793,10 +793,16 @@ def train_xgb(
             results, X_train.shape[1]
         ),
     )
+    patience = max(10, int(0.1 * config["n_estimators"]))
     xgb.train(
         config,
         dtrain,
+        num_boost_round=config[
+            "n_estimators"
+        ],  # num_boost_round is the number of boosting iterations,
+        # equal to n_estimators in scikit-learn
         evals=[(dtrain, "train"), (dval, "val")],
         callbacks=[checkpoint_callback],
         custom_metric=custom_xgb_metric,
+        early_stopping_rounds=patience,
     )

--- a/ritme/tests/test_model_static_searchspace.py
+++ b/ritme/tests/test_model_static_searchspace.py
@@ -149,6 +149,7 @@ class TestStaticSearchSpace(unittest.TestCase):
                 "xgb",
                 ss.get_xgb_space,
                 {
+                    "n_estimators": 100,
                     "max_depth": 6,
                     "min_child_weight": 2,
                     "subsample": 0.9,
@@ -280,12 +281,13 @@ class TestStaticSearchSpace(unittest.TestCase):
                 {
                     "subsample": {"min": 0.7, "max": 1.0},
                     "eta": {"min": 0.01, "max": 0.3, "log": True},
-                    "gamma": {"min": 0.0, "max": 5.0, "step": 0.1},
+                    "gamma": {"min": 1e-3, "max": 5.0, "log": True},
                     "reg_alpha": {"min": 1e-10, "max": 1.0, "log": True},
                     "reg_lambda": {"min": 1e-10, "max": 1.0, "log": True},
                     "colsample_bytree": {"min": 0.3, "max": 1.0},
                 },
                 {
+                    "n_estimators": {"min": 50, "max": 3000, "log": True},
                     "max_depth": {"min": 2, "max": 10},
                     "min_child_weight": {"min": 0, "max": 4},
                     "num_parallel_tree": {"min": 1, "max": 3, "step": 1},
@@ -381,12 +383,13 @@ class TestStaticSearchSpace(unittest.TestCase):
                 {
                     "subsample": {"min": 0.8, "max": 1.0},
                     "eta": {"min": 0.05, "max": 0.2, "log": True},
-                    "gamma": {"min": 0.1, "max": 3.0, "step": 0.1},
+                    "gamma": {"min": 0.1, "max": 3.0, "log": False},
                     "reg_alpha": {"min": 0.1, "max": 0.5, "log": True},
                     "reg_lambda": {"min": 0.1, "max": 0.5, "log": True},
                     "colsample_bytree": {"min": 0.7, "max": 0.8},
                 },
                 {
+                    "n_estimators": {"min": 5, "max": 100, "log": True},
                     "max_depth": {"min": 3, "max": 7},
                     "min_child_weight": {"min": 1, "max": 3},
                     "num_parallel_tree": {"min": 2, "max": 4, "step": 1},

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -283,6 +283,7 @@ class TestTrainables(unittest.TestCase):
     ):
         # Arrange
         config = {
+            "n_estimators": 100,
             "max_depth": 6,
             "min_child_weight": 3,
             "subsample": 0.9,
@@ -486,6 +487,7 @@ class TestTrainableLogging(unittest.TestCase):
             "weight_decay": 0.0,
             "early_stopping_patience": 3,
             "early_stopping_min_delta": 0.0,
+            "n_estimators": 100,
         }
         for i in range(search_space["n_hidden_layers"]):
             search_space[f"n_units_hl{i}"] = 2


### PR DESCRIPTION
this PR fixes specific trainables, namely:
* XGB by adding n_estimators and early stopping
* nn_corn by unsqueezing only for 2-class targets
* nn_class by rounding consistently in a torch-way (different to numpy)

Additionally, it refines the search space insights in the MLflow notebook.