### PR TITLE
FIX: MLflow postproc eval

### DIFF
--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -133,7 +133,8 @@
       "source": [
         "# post-process data_transform entry - only needed in MLflow since WandB updates\n",
         "# these automatically\n",
-        "all_trials = post_process_data_transform(all_trials)"
+        "if \"params.data_enrich\" in all_trials.columns:\n",
+        "    all_trials = post_process_data_transform(all_trials)"
       ]
     },
     {

--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -133,8 +133,7 @@
       "source": [
         "# post-process data_transform entry - only needed in MLflow since WandB updates\n",
         "# these automatically\n",
-        "if \"params.data_enrich\" in all_trials.columns:\n",
-        "    all_trials = post_process_data_transform(all_trials)"
+        "all_trials = post_process_data_transform(all_trials)"
       ]
     },
     {

--- a/ritme/evaluate_mlflow.py
+++ b/ritme/evaluate_mlflow.py
@@ -1,3 +1,5 @@
+import ast
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import plotly.express as px
@@ -410,12 +412,24 @@ def post_process_data_transform(all_trials):
     #  get number of metadata fields
     proc_trials.loc[proc_trials["params.data_enrich"] == "None", "nb_md_fts"] = 0
     proc_trials.loc[proc_trials["params.data_enrich"] == "shannon", "nb_md_fts"] = 1
-    proc_trials.loc[
-        proc_trials["params.data_enrich"] == "metadata_only", "nb_md_fts"
-    ] = proc_trials["params.data_enrich_with"].str.len()
-    proc_trials.loc[
-        proc_trials["params.data_enrich"] == "shannon_and_metadata", "nb_md_fts"
-    ] = (proc_trials["params.data_enrich_with"].str.len()) + 1
+
+    if "params.data_enrich_with" in proc_trials.columns:
+        nb_enrich_fts = (
+            proc_trials["params.data_enrich_with"]
+            .where(
+                proc_trials["params.data_enrich_with"].notna()
+                & (proc_trials["params.data_enrich_with"] != "None"),
+                "[]",
+            )
+            .map(ast.literal_eval)
+            .str.len()
+        )
+        proc_trials.loc[
+            proc_trials["params.data_enrich"] == "metadata_only", "nb_md_fts"
+        ] = nb_enrich_fts
+        proc_trials.loc[
+            proc_trials["params.data_enrich"] == "shannon_and_metadata", "nb_md_fts"
+        ] = (nb_enrich_fts + 1)
 
     # from this retrieve # microbiome features
     proc_trials["nb_microbiome_fts"] = (

--- a/ritme/tests/test_config_files.py
+++ b/ritme/tests/test_config_files.py
@@ -87,7 +87,23 @@ class TestConfigFiles(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("linreg", {"alpha": ["min", "max"], "l1_ratio": ["min", "max"]}),
+            (
+                "linreg",
+                {
+                    "alpha": ["min", "max"],
+                    "l1_ratio": ["min", "max"],
+                    "start_points_to_evaluate": [
+                        {
+                            "alpha": 0.1,
+                            "data_aggregation": "tax_class",
+                            "data_enrich": None,
+                            "data_selection": "abundance_threshold",
+                            "data_transform": "clr",
+                            "l1_ratio": 0.5,
+                        }
+                    ],
+                },
+            ),
             (
                 "rf",
                 {


### PR DESCRIPTION
this PR fixes the MLflow specific hyperparameter postprocessing in cases where the MLflow logs do not contain the field "params.data_enrich_with" - which is the case for trac-model-only experiments.