### PR TITLE
FIX: reduced xgb logging

### DIFF
--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -795,7 +795,8 @@ def train_xgb(
         results_postprocessing_fn=lambda results: add_nb_features_to_results(
             results, X_train.shape[1]
         ),
-        frequency=1,  # Save checkpoint every iteration
+        frequency=0,
+        checkpoint_at_end=True,
     )
     patience = max(10, int(0.1 * config["n_estimators"]))
     xgb.train(


### PR DESCRIPTION
this PR reduces the number of checkpoints logged when training a xgb trainable. With the former settings, most allocated training time was actually used for logging instead of for training.

Now this I/O bound is resolved, the drawback is that with the current settings, performance during training is no longer tracked.

see issue #84 