### PR TITLE
ENH: Inode-efficient storage for experiment logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export HTTP_PROXY=http://proxy.example.com:8080
 For a template on how to evaluate your models see the section on [model training evaluation](#model-training-evaluation).
 
 ### Set-up MLflow with *ritme*
-In case of using MLflow you can view your models with `mlflow ui` from within the path where the logs were saved (which is outputted when running `find_best_model_config` as "You can view the model logs by launching MLflow UI from within folder : <folder_name>"). This is rather slow when many trials or experiments were launched - then viewing logs via the Python API is better suited. For more information check out the [official MLflow documentation](https://mlflow.org/docs/latest/index.html).
+In case of using MLflow you can monitor live training progress with `mlflow ui` — the full command is printed when `find_best_model_config` starts. After training completes, all trial logs are consolidated into a single CSV file (`mlflow_logs.csv`) in the experiment directory and temporary tracking files are removed automatically.
 
 For a template on how to evaluate your models see the section on [model training evaluation](#model-training-evaluation).
 
@@ -131,7 +131,7 @@ For a template on how to evaluate your models see the section on [model training
 We provide example templates to help you evaluate your *ritme* models for both supported tracking services:
 * for WandB visit [this report](https://wandb.ai/ritme/trials_wandb/reports/Template-for-ritme-training-evaluation--VmlldzoxMzE1MTQ5MQ?accessToken=2yuzgiu4ke2r3ky5c894nnygguse8xh9mt5ky3g7p43mcirbmhv504ruipny54l5) - simply copy the template and update the run set at the end of the report to your own experiment.
 
-* for MLflow see the notebook [`experiments/evaluate_trials_mlflow.ipynb`](https://github.com/adamovanja/ritme/blob/main/experiments/evaluate_trials_mlflow.ipynb).
+* for MLflow see the notebook [`experiments/evaluate_trials_mlflow.ipynb`](https://github.com/adamovanja/ritme/blob/main/experiments/evaluate_trials_mlflow.ipynb), which loads the consolidated `mlflow_logs.csv` from the experiment directory.
 
 ## Note on reproducibility
 When you enable `"fully_reproducible": true` in your experiment configuration, all runs on identical hardware will produce fully reproducible results, albeit with a potential impact on efficiency and performance. This guarantee becomes particularly relevant when executing a large number of trials in parallel. (For small-scale experiments — e.g. with 2 trials — you will often observe identical results even with `"fully_reproducible": false`.)

--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -9,7 +9,7 @@
         "\n",
         "This notebook shows how the output from the method `find_best_model_config` of the *ritme* package can be evaluated when the experiments are tracked with MLflow.\n",
         "\n",
-        "The only user input required is the path to the MLflow logs (variable `log_folder_location`). For reproducibility the exact experiment is rerun (section [Run experiment](#run-experiment)) if it does not exist yet (depending on your compute power this might take a while to run).\n"
+        "Trial logs are stored as a consolidated CSV file (`mlflow_logs.csv`) in the experiment directory. The only user input required is the path to the experiment folder (variable `experiment_folder`). For reproducibility the exact experiment is rerun (section [Run experiment](#run-experiment)) if it does not exist yet (depending on your compute power this might take a while to run)."
       ]
     },
     {
@@ -27,21 +27,20 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "import os\n",
         "import warnings\n",
         "\n",
-        "import mlflow\n",
+        "import pandas as pd\n",
         "\n",
         "from ritme.evaluate_mlflow import (\n",
         "    barplot_metric,\n",
+        "    boxplot_metric,\n",
         "    extract_run_config,\n",
         "    parallel_coordinates_plot,\n",
-        "    plot_avg_history_per_model_type,\n",
         "    plot_complexity_vs_metric,\n",
-        "    plot_metric_history_per_model_type,\n",
         "    plot_trend_over_time,\n",
         "    post_process_data_transform,\n",
         "    violinplot_metric,\n",
-        "    boxplot_metric,\n",
         ")\n",
         "\n",
         "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
@@ -60,8 +59,8 @@
       "source": [
         "######## USER INPUTS ########\n",
         "\n",
-        "# path to MLflow logs\n",
-        "log_folder_location = \"ritme_example_logs/trials_mlflow/mlruns\"\n",
+        "# path to experiment folder containing mlflow_logs.csv\n",
+        "experiment_folder = \"ritme_example_logs/trials_mlflow\"\n",
         "\n",
         "# whether to only analyze one model type or all (=\"all\")\n",
         "model_type = \"all\"\n",
@@ -114,12 +113,12 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# extract all trial information\n",
-        "mlflow.set_tracking_uri(log_folder_location)\n",
+        "# load trial information from consolidated CSV\n",
+        "csv_path = os.path.join(experiment_folder, \"mlflow_logs.csv\")\n",
+        "all_trials = pd.read_csv(csv_path)\n",
         "\n",
-        "all_trials = mlflow.search_runs(\n",
-        "    order_by=[\"metrics.rmse_val ASC\"], search_all_experiments=True\n",
-        ")\n",
+        "# sort by validation RMSE (ascending)\n",
+        "all_trials = all_trials.sort_values(\"metrics.rmse_val\").reset_index(drop=True)\n",
         "\n",
         "print(f\"Found {all_trials.shape[0]} trials\")"
       ]
@@ -563,7 +562,9 @@
       "id": "cb43474a",
       "metadata": {},
       "source": [
-        "## Training over time"
+        "## Training over time\n",
+        "\n",
+        "Per-step training history (individual training curves per trial) is not available in the consolidated CSV. The trend plot below shows final metrics over trial start time, which can indicate whether the search algorithm improves over time."
       ]
     },
     {
@@ -580,61 +581,6 @@
         "    plot_trend_over_time(\n",
         "        model_trials, f\"metrics.{metric}\", window=20, title_prefix=f\"Model: {model}\"\n",
         "    )"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "139cf8c5",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "client = mlflow.tracking.MlflowClient(tracking_uri=log_folder_location)\n",
-        "\n",
-        "# one figure per model type\n",
-        "for model_type in all_trials[\"params.model\"].unique():\n",
-        "    model_trials = all_trials[all_trials[\"params.model\"] == model_type]\n",
-        "    plot_metric_history_per_model_type(metric, client, model_trials)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "64e19ead",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# plot all metric history in one plot\n",
-        "plot_metric_history_per_model_type(metric, client, all_trials)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "44980550",
-      "metadata": {},
-      "source": [
-        "* If per model type later launched trials yield smaller RMSE train then the selected search algorithm works\n",
-        "* *Note:* The classification network (`nn_class`) is trained by minimizing the cross\u2010entropy loss, and the ordinal\u2010regression variant (`nn_corn`) is trained by minimizing the CORN loss.  herefore, training curves based on MSE\u2010derived metrics (e.g. RMSE) are not guaranteed to decrease monotonically during optimization for these models."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ca525e36",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "plot_avg_history_per_model_type(\"rmse_train\", client, all_trials)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4408a0b0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "plot_avg_history_per_model_type(\"rmse_val\", client, all_trials)"
       ]
     },
     {
@@ -673,7 +619,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.20"
+      "version": "3.13.12"
     }
   },
   "nbformat": 4,

--- a/experiments/ritme_example_usage.ipynb
+++ b/experiments/ritme_example_usage.ipynb
@@ -22,35 +22,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Fetch data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's demonstrate `ritme` by using the example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/). To run the CLI and the Python API examples you first have to fetch the data and extract the files from the fetched QIIME2 artifacts:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "vscode": {
-          "languageId": "shellscript"
-        }
-      },
-      "outputs": [],
-      "source": [
-        "! scripts/fetch_moving_pictures_data.sh\n",
-        "! scripts/convert_qiime2_artifacts.sh"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Python API example usage"
+        "## Setup"
       ]
     },
     {
@@ -75,6 +47,44 @@
         "%load_ext autoreload\n",
         "%autoreload 2\n",
         "%matplotlib inline"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fetch data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's demonstrate `ritme` by using the example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/). To run the CLI and the Python API examples you first have to fetch the data and extract the files from the fetched QIIME2 artifacts:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "vscode": {
+          "languageId": "shellscript"
+        }
+      },
+      "outputs": [],
+      "source": [
+        "! ./scripts/fetch_moving_pictures_data.sh\n",
+        "! ./scripts/convert_qiime2_artifacts.sh data/movpic_table.qza \\\n",
+        "  --metadata data/movpic_metadata.tsv \\\n",
+        "  --taxonomy data/movpic_taxonomy.qza \\\n",
+        "  --tree data/movpic_tree.qza"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Python API example usage"
       ]
     },
     {

--- a/ritme/evaluate_mlflow.py
+++ b/ritme/evaluate_mlflow.py
@@ -402,7 +402,8 @@ def extract_run_config(trials):
     are displayed
     """
     varying_cols = trials.columns[trials.nunique() > 1]
-    varying_cols = varying_cols.drop("artifact_uri")
+    if "artifact_uri" in varying_cols:
+        varying_cols = varying_cols.drop("artifact_uri")
     return trials[varying_cols]
 
 

--- a/ritme/evaluate_models.py
+++ b/ritme/evaluate_models.py
@@ -79,6 +79,7 @@ def load_nn_model(result: Result) -> NeuralNet:
     model = NeuralNet.load_from_checkpoint(
         checkpoint_path=ckpt_path,
         map_location=device,
+        weights_only=False,
     )
     model.to(device)
     return model

--- a/ritme/find_best_model_config.py
+++ b/ritme/find_best_model_config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 
 import pandas as pd
 import skbio
@@ -100,12 +101,58 @@ def _process_phylogeny(phylo_tree: skbio.TreeNode, ft: pd.DataFrame) -> skbio.Tr
 
 
 @helper_function
+def _extract_mlflow_logs_to_csv(tracking_uri: str, output_dir: str) -> None:
+    """Extract MLflow run logs to a consolidated CSV file.
+
+    Reads all experiments and runs from the MLflow tracking backend and saves
+    them as a single CSV with run info, parameters, metrics, and tags.
+    """
+    from mlflow.tracking import MlflowClient
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    experiments = client.search_experiments()
+
+    exp_ids = [e.experiment_id for e in experiments]
+    if not exp_ids:
+        return
+
+    exp_name_map = {e.experiment_id: e.name for e in experiments}
+    runs = client.search_runs(experiment_ids=exp_ids)
+    if not runs:
+        return
+
+    all_run_data = []
+    for run in runs:
+        row = {
+            "run_id": run.info.run_id,
+            "experiment_id": run.info.experiment_id,
+            "experiment_name": exp_name_map.get(run.info.experiment_id, ""),
+            "status": run.info.status,
+            "start_time": pd.Timestamp(run.info.start_time, unit="ms")
+            if run.info.start_time
+            else None,
+            "end_time": pd.Timestamp(run.info.end_time, unit="ms")
+            if run.info.end_time
+            else None,
+        }
+        row.update({f"params.{k}": v for k, v in run.data.params.items()})
+        row.update({f"metrics.{k}": v for k, v in run.data.metrics.items()})
+        row.update({f"tags.{k}": v for k, v in run.data.tags.items()})
+        all_run_data.append(row)
+
+    df = pd.DataFrame(all_run_data)
+    df.to_csv(os.path.join(output_dir, "mlflow_logs.csv"), index=False)
+
+
+@helper_function
 def _define_model_tracker(tracking_uri: str, path_exp: str) -> str:
     if tracking_uri == "mlruns":
-        path_tracker = os.path.join(path_exp, tracking_uri)
+        db_path = os.path.join(path_exp, "mlflow.db")
+        path_tracker = f"sqlite:///{db_path}"
         print(
-            f"You can view the model logs by launching MLflow UI from within folder "
-            f": {path_exp}."
+            "MLflow tracking enabled. Logs will be extracted to CSV after "
+            "experiment completion. To monitor live progress run: "
+            f"mlflow ui --backend-store-uri {path_tracker}"
         )
     else:
         path_tracker = "wandb"
@@ -165,9 +212,6 @@ def find_best_model_config(
     path_exp = _define_experiment_path(config, path_store_model_logs)
     _save_config(config, path_exp, "experiment_config.json")
 
-    # define model tracker
-    path_tracker = _define_model_tracker(config["tracking_uri"], path_exp)
-
     # ! Process taxonomy and phylogeny by microbial feature table
     ft_col = [x for x in train_val.columns if x.startswith("F")]
     if tax is not None:
@@ -175,31 +219,45 @@ def find_best_model_config(
     if tree_phylo is not None:
         tree_phylo = _process_phylogeny(tree_phylo, train_val[ft_col])
 
-    # ! Run all experiments on train_val
-    result_dic = run_all_trials(
-        train_val,
-        config["target"],
-        config["group_by_column"],
-        config.get("stratify_by", None),
-        config["seed_data"],
-        config["seed_model"],
-        tax,
-        tree_phylo,
-        path_tracker,
-        path_exp,
-        # time_budget for search
-        config["time_budget_s"],
-        config["max_cuncurrent_trials"],
-        model_types=config["ls_model_types"],
-        fully_reproducible=config["fully_reproducible"],
-        model_hyperparameters=config.get("model_hyperparameters", {}),
-        optuna_searchspace_sampler=config.get(
-            "optuna_searchspace_sampler", "TPESampler"
-        ),
-    )
+    # ! Run all experiments in a temporary directory to reduce inode usage.
+    # Trial directories and MLflow logs are created here, then only the
+    # consolidated outputs (best models, MLflow CSV) are kept in path_exp.
+    with tempfile.TemporaryDirectory() as tmp_storage:
+        path_tracker = _define_model_tracker(config["tracking_uri"], tmp_storage)
 
-    # ! Get best models of this experiment
-    best_model_dic = retrieve_n_init_best_models(result_dic, train_val)
+        result_dic = run_all_trials(
+            train_val,
+            config["target"],
+            config["group_by_column"],
+            config.get("stratify_by", None),
+            config["seed_data"],
+            config["seed_model"],
+            tax,
+            tree_phylo,
+            path_tracker,
+            tmp_storage,
+            # time_budget for search
+            config["time_budget_s"],
+            config["max_cuncurrent_trials"],
+            model_types=config["ls_model_types"],
+            fully_reproducible=config["fully_reproducible"],
+            model_hyperparameters=config.get("model_hyperparameters", {}),
+            optuna_searchspace_sampler=config.get(
+                "optuna_searchspace_sampler", "TPESampler"
+            ),
+        )
+
+        # ! Get best models of this experiment
+        best_model_dic = retrieve_n_init_best_models(result_dic, train_val)
+
+        # ! Extract MLflow logs to CSV before temp directory cleanup
+        if config["tracking_uri"] == "mlruns":
+            _extract_mlflow_logs_to_csv(path_tracker, path_exp)
+            print(f"MLflow logs saved to: {os.path.join(path_exp, 'mlflow_logs.csv')}")
+
+    # Update model paths to the permanent experiment directory
+    for tmodel in best_model_dic.values():
+        tmodel.path = path_exp
 
     return best_model_dic, path_exp
 

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -7,6 +7,11 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import joblib
 import numpy as np
+
+# classo uses np.infty which was removed in NumPy 2.0
+if not hasattr(np, "infty"):
+    np.infty = np.inf
+
 import pandas as pd
 import ray
 import skbio

--- a/ritme/tests/test_find_best_model_config.py
+++ b/ritme/tests/test_find_best_model_config.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 from io import StringIO
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pandas as pd
 import skbio
@@ -13,6 +13,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
 from ritme.find_best_model_config import (
     _define_experiment_path,
     _define_model_tracker,
+    _extract_mlflow_logs_to_csv,
     _load_experiment_config,
     _load_phylogeny,
     _load_taxonomy,
@@ -185,7 +186,7 @@ class TestFindBestModelConfig(unittest.TestCase):
     def test_define_model_tracker_mlflow(self):
         with patch("builtins.print") as mock_print:
             path_tracker = _define_model_tracker("mlruns", "experiments/models")
-            self.assertEqual(path_tracker, "experiments/models/mlruns")
+            self.assertEqual(path_tracker, "sqlite:///experiments/models/mlflow.db")
             mock_print.assert_called_once()
 
     def test_define_model_tracker_wandb(self):
@@ -208,16 +209,20 @@ class TestFindBestModelConfig(unittest.TestCase):
             ):
                 _define_experiment_path(self.config, temp_dir)
 
+    @patch("ritme.find_best_model_config._extract_mlflow_logs_to_csv")
     @patch("ritme.find_best_model_config.run_all_trials")
     @patch("ritme.find_best_model_config.retrieve_n_init_best_models")
     def test_find_best_model_config(
-        self, mock_retrieve_n_init_best_models, mock_run_all_trials
+        self,
+        mock_retrieve_n_init_best_models,
+        mock_run_all_trials,
+        mock_extract_mlflow,
     ):
         # Mock the return values of the functions
         mock_run_all_trials.return_value = {"model1": "result1", "model2": "result2"}
         mock_retrieve_n_init_best_models.return_value = {
-            "model1": "best_model1",
-            "model2": "best_model2",
+            "model1": MagicMock(),
+            "model2": MagicMock(),
         }
 
         # define phylo tree
@@ -236,6 +241,7 @@ class TestFindBestModelConfig(unittest.TestCase):
             # After adding stratify_by positional arg, tax and phylo shift one index
             assert_frame_equal(args[6], self.tax_renamed)
             self.assertEqual(str(args[7]), str(self.tree_phylo_filtered))
+            # Trial storage and mlruns are in a temp directory (not path_exp)
             mock_run_all_trials.assert_called_once_with(
                 ANY,  # train_val
                 self.config["target"],
@@ -245,8 +251,8 @@ class TestFindBestModelConfig(unittest.TestCase):
                 self.config["seed_model"],
                 ANY,  # processed tax
                 ANY,  # processed phylo
-                os.path.join(temp_dir, "test_experiment", "mlruns"),
-                os.path.join(temp_dir, "test_experiment"),
+                ANY,  # path_tracker (temp dir mlruns)
+                ANY,  # tmp_storage (temp dir)
                 self.config["time_budget_s"],
                 self.config["max_cuncurrent_trials"],
                 model_types=self.config["ls_model_types"],
@@ -254,18 +260,29 @@ class TestFindBestModelConfig(unittest.TestCase):
                 model_hyperparameters={},
                 optuna_searchspace_sampler="TPESampler",
             )
+            # Verify temp storage paths are NOT under path_exp
+            self.assertNotEqual(args[8], os.path.join(path_exp, "mlruns"))
+            self.assertNotEqual(args[9], path_exp)
+            # Verify MLflow extraction was called
+            mock_extract_mlflow.assert_called_once()
 
+    @patch("ritme.find_best_model_config._extract_mlflow_logs_to_csv")
     @patch("ritme.find_best_model_config.run_all_trials")
     @patch("ritme.find_best_model_config.retrieve_n_init_best_models")
     def test_find_best_model_config_with_stratify_by(
-        self, mock_retrieve_n_init_best_models, mock_run_all_trials
+        self,
+        mock_retrieve_n_init_best_models,
+        mock_run_all_trials,
+        mock_extract_mlflow,
     ):
         config_w_strat = self.config.copy()
         config_w_strat["stratify_by"] = ["stratify_column"]
         mock_run_all_trials.return_value = {"model1": "result1", "model2": "result2"}
+        mock_tmodel1 = MagicMock()
+        mock_tmodel2 = MagicMock()
         mock_retrieve_n_init_best_models.return_value = {
-            "model1": "best_model1",
-            "model2": "best_model2",
+            "model1": mock_tmodel1,
+            "model2": mock_tmodel2,
         }
         tree_phylo = skbio.TreeNode.read([self.tree_str])
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -275,10 +292,9 @@ class TestFindBestModelConfig(unittest.TestCase):
             args, _ = mock_run_all_trials.call_args
             self.assertEqual(args[3], ["stratify_column"])  # stratify_by
             mock_run_all_trials.assert_called_once()
-            self.assertEqual(
-                best_model_dic,
-                {"model1": "best_model1", "model2": "best_model2"},
-            )
+            self.assertEqual(set(best_model_dic.keys()), {"model1", "model2"})
+            self.assertIs(best_model_dic["model1"], mock_tmodel1)
+            self.assertIs(best_model_dic["model2"], mock_tmodel2)
             self.assertTrue(path_exp.startswith(f"{temp_dir}/test_experiment"))
 
     @patch("ritme.find_best_model_config._load_experiment_config")
@@ -358,6 +374,176 @@ class TestFindBestModelConfig(unittest.TestCase):
         args, _ = mock_find_best_model_config.call_args
         self.assertEqual(args[2], None)
         self.assertEqual(args[3], None)
+
+
+class TestExtractMlflowLogsToCsv(unittest.TestCase):
+    @patch("mlflow.tracking.MlflowClient")
+    def test_extract_mlflow_logs_to_csv(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+
+        mock_exp = MagicMock()
+        mock_exp.experiment_id = "1"
+        mock_exp.name = "xgb"
+        mock_client.search_experiments.return_value = [mock_exp]
+
+        mock_run = MagicMock()
+        mock_run.info.run_id = "run123"
+        mock_run.info.experiment_id = "1"
+        mock_run.info.status = "FINISHED"
+        mock_run.info.start_time = 1000
+        mock_run.info.end_time = 2000
+        mock_run.data.params = {"model": "xgb", "lr": "0.1"}
+        mock_run.data.metrics = {"rmse_val": 0.5, "nb_features": 10.0}
+        mock_run.data.tags = {"experiment_tag": "test_exp"}
+        mock_client.search_runs.return_value = [mock_run]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_mlflow_logs_to_csv("sqlite:///fake/mlflow.db", temp_dir)
+
+            csv_path = os.path.join(temp_dir, "mlflow_logs.csv")
+            self.assertTrue(os.path.exists(csv_path))
+
+            df = pd.read_csv(csv_path)
+            self.assertEqual(len(df), 1)
+            self.assertEqual(df.loc[0, "run_id"], "run123")
+            self.assertEqual(df.loc[0, "experiment_name"], "xgb")
+            self.assertEqual(df.loc[0, "status"], "FINISHED")
+            self.assertAlmostEqual(df.loc[0, "metrics.rmse_val"], 0.5)
+            self.assertEqual(df.loc[0, "params.model"], "xgb")
+            self.assertEqual(df.loc[0, "tags.experiment_tag"], "test_exp")
+
+    @patch("mlflow.tracking.MlflowClient")
+    def test_extract_mlflow_logs_multiple_experiments(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+
+        mock_exp1 = MagicMock()
+        mock_exp1.experiment_id = "1"
+        mock_exp1.name = "xgb"
+        mock_exp2 = MagicMock()
+        mock_exp2.experiment_id = "2"
+        mock_exp2.name = "rf"
+        mock_client.search_experiments.return_value = [mock_exp1, mock_exp2]
+
+        mock_run1 = MagicMock()
+        mock_run1.info.run_id = "run1"
+        mock_run1.info.experiment_id = "1"
+        mock_run1.info.status = "FINISHED"
+        mock_run1.info.start_time = 1000
+        mock_run1.info.end_time = 2000
+        mock_run1.data.params = {"model": "xgb"}
+        mock_run1.data.metrics = {"rmse_val": 0.5}
+        mock_run1.data.tags = {}
+
+        mock_run2 = MagicMock()
+        mock_run2.info.run_id = "run2"
+        mock_run2.info.experiment_id = "2"
+        mock_run2.info.status = "FINISHED"
+        mock_run2.info.start_time = 3000
+        mock_run2.info.end_time = 4000
+        mock_run2.data.params = {"model": "rf"}
+        mock_run2.data.metrics = {"rmse_val": 0.3}
+        mock_run2.data.tags = {}
+        mock_client.search_runs.return_value = [mock_run1, mock_run2]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_mlflow_logs_to_csv("sqlite:///fake/mlflow.db", temp_dir)
+            df = pd.read_csv(os.path.join(temp_dir, "mlflow_logs.csv"))
+            self.assertEqual(len(df), 2)
+            self.assertEqual(set(df["experiment_name"]), {"xgb", "rf"})
+
+    @patch("mlflow.tracking.MlflowClient")
+    def test_extract_mlflow_logs_no_experiments(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+        mock_client.search_experiments.return_value = []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_mlflow_logs_to_csv("sqlite:///fake/mlflow.db", temp_dir)
+            csv_path = os.path.join(temp_dir, "mlflow_logs.csv")
+            self.assertFalse(os.path.exists(csv_path))
+
+    @patch("mlflow.tracking.MlflowClient")
+    def test_extract_mlflow_logs_no_runs(self, mock_client_class):
+        mock_client = mock_client_class.return_value
+
+        mock_exp = MagicMock()
+        mock_exp.experiment_id = "0"
+        mock_exp.name = "Default"
+        mock_client.search_experiments.return_value = [mock_exp]
+        mock_client.search_runs.return_value = []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _extract_mlflow_logs_to_csv("sqlite:///fake/mlflow.db", temp_dir)
+            csv_path = os.path.join(temp_dir, "mlflow_logs.csv")
+            self.assertFalse(os.path.exists(csv_path))
+
+    @patch("ritme.find_best_model_config._extract_mlflow_logs_to_csv")
+    @patch("ritme.find_best_model_config.run_all_trials")
+    @patch("ritme.find_best_model_config.retrieve_n_init_best_models")
+    def test_find_best_model_config_no_mlflow_extraction_for_wandb(
+        self,
+        mock_retrieve,
+        mock_run_all_trials,
+        mock_extract_mlflow,
+    ):
+        config = {
+            "tracking_uri": "wandb",
+            "fully_reproducible": False,
+            "experiment_tag": "test_wandb",
+            "target": "target_column",
+            "group_by_column": "group_column",
+            "seed_data": 42,
+            "seed_model": 42,
+            "time_budget_s": 10,
+            "max_cuncurrent_trials": 2,
+            "ls_model_types": ["xgb"],
+            "model_hyperparameters": {},
+        }
+        mock_run_all_trials.return_value = {"xgb": "result"}
+        mock_retrieve.return_value = {"xgb": MagicMock()}
+
+        train_val = pd.DataFrame(
+            {"F1": [0.1, 0.2], "target_column": [1, 2], "group_column": ["a", "b"]}
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            find_best_model_config(config, train_val, path_store_model_logs=temp_dir)
+            mock_extract_mlflow.assert_not_called()
+
+    @patch("ritme.find_best_model_config._extract_mlflow_logs_to_csv")
+    @patch("ritme.find_best_model_config.run_all_trials")
+    @patch("ritme.find_best_model_config.retrieve_n_init_best_models")
+    def test_find_best_model_config_updates_model_paths(
+        self,
+        mock_retrieve,
+        mock_run_all_trials,
+        mock_extract_mlflow,
+    ):
+        mock_run_all_trials.return_value = {"xgb": "result"}
+
+        mock_tmodel = MagicMock()
+        mock_tmodel.path = "/tmp/some_temp_trial_dir"
+        mock_retrieve.return_value = {"xgb": mock_tmodel}
+
+        train_val = pd.DataFrame(
+            {"F1": [0.1, 0.2], "target_column": [1, 2], "group_column": ["a", "b"]}
+        )
+        config = {
+            "tracking_uri": "mlruns",
+            "fully_reproducible": False,
+            "experiment_tag": "test_path_update",
+            "target": "target_column",
+            "group_by_column": "group_column",
+            "seed_data": 42,
+            "seed_model": 42,
+            "time_budget_s": 10,
+            "max_cuncurrent_trials": 2,
+            "ls_model_types": ["xgb"],
+            "model_hyperparameters": {},
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            best_models, path_exp = find_best_model_config(
+                config, train_val, path_store_model_logs=temp_dir
+            )
+            self.assertEqual(best_models["xgb"].path, path_exp)
 
 
 if __name__ == "__main__":

--- a/ritme/tests/test_tune_models.py
+++ b/ritme/tests/test_tune_models.py
@@ -177,11 +177,8 @@ class TestHelpersTuneModels(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "No WANDB_ENTITY found in .env file."):
             _load_wandb_entity()
 
-    @patch("ritme.tune_models.os.path.exists")
-    @patch("ritme.tune_models.os.makedirs")
-    def test_define_callbacks_mlflow(self, mock_makedirs, mock_exists):
-        mock_exists.return_value = False
-        tracking_uri = "mlruns"
+    def test_define_callbacks_mlflow(self):
+        tracking_uri = "sqlite:///tmp/mlflow.db"
         exp_name = "test_exp"
         experiment_tag = "test_tag"
 
@@ -192,8 +189,6 @@ class TestHelpersTuneModels(unittest.TestCase):
         self.assertEqual(callbacks[0].tracking_uri, tracking_uri)
         self.assertEqual(callbacks[0].experiment_name, exp_name)
         self.assertEqual(callbacks[0].tags, {"experiment_tag": experiment_tag})
-        mock_exists.assert_called_once_with(tracking_uri)
-        mock_makedirs.assert_called_once_with(tracking_uri)
 
     @patch("ritme.tune_models._load_wandb_api_key")
     @patch("ritme.tune_models._load_wandb_entity")
@@ -239,7 +234,7 @@ class TestMainTuneModels(unittest.TestCase):
         self.time_budget_s = 5
         self.max_concurrent_trials = 2
         self.model_hyperparameters = {}
-        self.mlflow_uri = "mlruns"
+        self.mlflow_uri = "sqlite:///tmp/experiment/mlflow.db"
 
     @patch("ritme.tune_models.init")
     @patch("ritme.tune_models.ray.cluster_resources")

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -179,9 +179,7 @@ def _define_callbacks(tracking_uri: str, exp_name: str, experiment_tag: str) -> 
     """Define callbacks based on the tracking URI."""
     callbacks = []
 
-    if tracking_uri.endswith("mlruns"):
-        if not os.path.exists(tracking_uri):
-            os.makedirs(tracking_uri)
+    if tracking_uri.startswith("sqlite:///"):
         callbacks.append(
             MLflowLoggerCallback(
                 tracking_uri=tracking_uri,


### PR DESCRIPTION
This PR resolves issue #90. `find_best_model_config` now runs all trials in a temporary directory that is removed after best models are extracted. This eliminates the per-trial Ray Tune files and MLflow tracking files from the permanent experiment directory, reducing inode usage from hundreds of files to a handful.

## Changes
- Redirect Ray Tune `storage_path` and MLflow tracking to a `tempfile.TemporaryDirectory`; best models are loaded into memory before cleanup
- Consolidate MLflow run metadata (params, metrics, tags) into `mlflow_logs.csv` in the experiment directory before the temp directory is removed
- Replace deprecated MLflow filesystem backend (`mlruns/`) with SQLite
- Update `evaluate_trials_mlflow.ipynb` to read from CSV instead of querying MLflow
- Print `mlflow ui` command at training start for live monitoring

## Final experiment directory
```
{path_exp}/
  experiment_config.json
  mlflow_logs.csv             (when tracking_uri="mlruns")
  {model_type}_best_model.pkl
```

User-facing config unchanged — `"tracking_uri": "mlruns"` still works; the SQLite translation is internal.

## Files changed
- `ritme/find_best_model_config.py` — temp dir, SQLite backend, CSV extraction
- `ritme/tune_models.py` — SQLite callback detection
- `ritme/evaluate_mlflow.py` — handle missing `artifact_uri` column
- `ritme/tests/test_find_best_model_config.py` — updated + 6 new tests
- `ritme/tests/test_tune_models.py` — updated for SQLite URIs
- `experiments/evaluate_trials_mlflow.ipynb` — reads from CSV
- `README.md` — updated MLflow setup section
- `.gitignore` — ignore `.claude/`
