### PR TITLE
ADD: SHAP-based feature importance explanation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,19 +34,20 @@ The package supports two modes:
 | `ritme/tune_models.py` | Runs Ray Tune trials, enforces model type restrictions |
 | `ritme/evaluate_models.py` | `TunedModel` class with per-snapshot predict pipeline |
 | `ritme/evaluate_tuned_models.py` | Final evaluation on train + test sets |
+| `ritme/explain_features.py` | SHAP feature importance computation and plotting |
 | `ritme/feature_space/` | Feature engineering: aggregate, select, transform, enrich |
 | `ritme/feature_space/_process_train.py` | Per-snapshot feature processing pipeline |
 | `ritme/feature_space/utils.py` | Snapshot utilities (`_slice_snapshot`, `_add_suffix`, `_PAST_SUFFIX_RE`) |
 | `ritme/model_space/static_trainables.py` | Model trainables: linreg, xgb, rf, trac, nn_reg, nn_class, nn_corn |
 | `ritme/model_space/static_searchspace.py` | Hyperparameter search spaces per model type |
-| `ritme/cli.py` | Typer CLI entry point (`ritme split-train-test`, `find-best-model-config`, `evaluate-tuned-models`) |
+| `ritme/cli.py` | Typer CLI entry point (`ritme split-train-test`, `find-best-model-config`, `evaluate-tuned-models`, `explain-features`) |
 | `ritme/evaluate_mlflow.py` | MLflow visualization utilities |
 | `config/` | Example experiment configuration files |
 | `experiments/` | Example usage notebooks |
 
 ## CLI and Python API pattern
 
-Each of the three main functions exists in two forms:
+Each of the four main functions exists in two forms:
 
 - **Python API** (e.g. `split_train_test()`): accepts in-memory objects (DataFrames, dicts, TreeNode) and returns results directly. Decorated with `@main_function`.
 - **CLI wrapper** (e.g. `cli_split_train_test()`): accepts file paths as strings, loads data, delegates to the Python API function, and writes outputs to disk. Also decorated with `@main_function`. Registered in `ritme/cli.py` via Typer.
@@ -56,6 +57,7 @@ Each of the three main functions exists in two forms:
 | `split_train_test()` | `cli_split_train_test()` | `ritme split-train-test` |
 | `find_best_model_config()` | `cli_find_best_model_config()` | `ritme find-best-model-config` |
 | `evaluate_tuned_models()` | `cli_evaluate_tuned_models()` | `ritme evaluate-tuned-models` |
+| `compute_shap_values()` | `cli_explain_features()` | `ritme explain-features` |
 
 Internal/private functions are decorated with `@helper_function`. Both decorators are defined in `ritme/_decorators.py` and are used purely as flags (no runtime behavior).
 
@@ -63,6 +65,7 @@ When modifying a main function's signature, update both the Python API and the C
 
 ## Important best practices
 When performing and changes or additions to this repos make sure to follow best practices in software development. making sure all added code is clearly structured, only contains comments when really needed. Any added functionality (= the difference to main branch) should be properly tested with unit tests.
+When testing new functionality always do it in an activated conda environment called `ritme` - if it does not exist yet, make sure to create with with `make create-env`. Never install packages in the base environment!
 
 ## Design constraints
 
@@ -102,6 +105,9 @@ ritme evaluate-tuned-models --help
 
 ### Testing
 - All new functionality must have corresponding tests in `ritme/tests/`.
+
+### Formatting
+- Ensure all code is formatted according to the pre-commit hooks in this repos.
 
 ### Commits
 - Imperative form, matching existing `git log` style.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ conda install -c adamova -c conda-forge -c bioconda -c pytorch ritme
 (If on a Apple Silicon chip, prefix the above installation with `CONDA_SUBDIR=osx-64` and run the following after activating the conda environnment: `conda config --env --set subdir osx-64`.)
 
 ## Usage
-*ritme* provides three main functions to prepare your data, find the best model configuration (feature + model class) for the specified target and evaluate the best model configuration on a test set. All of them can be run in the CLI or via the Python API. To see the arguments needed for each function run `ritme <function-name> --help` or have a look at the examples in the notebook [`experiments/ritme_example_usage.ipynb`](https://github.com/adamovanja/ritme/blob/main/experiments/ritme_example_usage.ipynb).
+*ritme* provides four main functions to prepare your data, find the best model configuration (feature + model class) for the specified target, evaluate the best model configuration on a test set and explain feature importance with SHAP. All of them can be run in the CLI or via the Python API. To see the arguments needed for each function run `ritme <function-name> --help` or have a look at the examples in the notebook [`experiments/ritme_example_usage.ipynb`](https://github.com/adamovanja/ritme/blob/main/experiments/ritme_example_usage.ipynb).
 
 | *ritme* function       | Description                                                                      |
 |------------------------|----------------------------------------------------------------------------------|
 | split_train_test       | Preprocess your dataset and split it into train-test (with static/dynamic feature, stratification and grouping options)                         |
 | find_best_model_config | Find the best model configuration (incl. feature representation and model class) |
 | evaluate_tuned_models  | Evaluate the best model configuration on the complete train and a left-out test set                     |
+| explain_features       | Compute SHAP feature importance for a specified best tuned model                        |
 
 ## Preprocess your dataset and split it into train-test with `split_train_test`
 
@@ -101,6 +102,30 @@ metrics_df, fig = evaluate_tuned_models(best_model_dict, exp_config, train, test
 ```
 
 Via the CLI, metrics are saved to `best_metrics.csv` and plots to `best_true_vs_pred.png` in the experiment directory.
+
+## Explain feature importance with `compute_shap_values`
+
+`compute_shap_values` uses [SHAP](https://shap.readthedocs.io/) (SHapley Additive exPlanations) to understand which features drive a single model's predictions. It builds the processed design matrix from raw data (reusing the exact feature engineering pipeline learned during training) and computes SHAP values on a test set. Supported model types: `linreg`, `rf`, ``xgboost``, and all neural networks. TRAC models are not supported because their coefficients already provide direct feature importance.
+
+```python
+from ritme.explain_features import compute_shap_values, plot_shap_summary, plot_shap_bar
+
+# compute SHAP values on test set (train_val is used as background)
+shap_values = compute_shap_values(best_model_dict["linreg"], train_val, test)
+
+# plot
+plot_shap_summary(shap_values, max_display=15, show=True)
+plot_shap_bar(shap_values, max_display=15, show=True)
+```
+
+The returned `shap.Explanation` object can also be used directly with any plotting function from the [shap](https://shap.readthedocs.io/) library.
+
+Via the CLI, SHAP values, summary plots, and bar plots are saved in the experiment directory:
+
+```shell
+ritme explain-features \
+  ritme_example_logs/example_linreg linreg data_splits/train_val.pkl data_splits/test.pkl
+```
 
 ## Model tracking
 In the run configuration file you can choose to track your trials with MLflow (`tracking_uri=="mlruns"`) or with WandB (`tracking_uri=="wandb"`).

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - scikit-learn
     - scipy
     - conda-forge::seaborn
+    - conda-forge::shap
     - torchmetrics
     - torchvision
     - typer

--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -627,10 +627,8 @@
         "with open(best_model_path, \"rb\") as f:\n",
         "    best_model = pickle.load(f)\n",
         "\n",
-        "train_val = pd.read_pickle(\n",
-        "    os.path.join(experiment_folder, \"../data_splits/train_val.pkl\")\n",
-        ")\n",
-        "test = pd.read_pickle(os.path.join(experiment_folder, \"../data_splits/test.pkl\"))\n",
+        "train_val = pd.read_pickle(\"data_splits_mlflow/train_val.pkl\")\n",
+        "test = pd.read_pickle(\"data_splits_mlflow/test.pkl\")\n",
         "\n",
         "shap_values = compute_shap_values(best_model, train_val, test)\n",
         "shap_values"
@@ -673,7 +671,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.12"
+      "version": "3.13.13"
     }
   },
   "nbformat": 4,

--- a/experiments/evaluate_trials_mlflow.ipynb
+++ b/experiments/evaluate_trials_mlflow.ipynb
@@ -28,6 +28,7 @@
       "outputs": [],
       "source": [
         "import os\n",
+        "import pickle\n",
         "import warnings\n",
         "\n",
         "import pandas as pd\n",
@@ -42,6 +43,7 @@
         "    post_process_data_transform,\n",
         "    violinplot_metric,\n",
         ")\n",
+        "from ritme.explain_features import compute_shap_values, plot_shap_bar, plot_shap_summary\n",
         "\n",
         "warnings.filterwarnings(\"ignore\", category=FutureWarning)\n",
         "\n",
@@ -600,6 +602,58 @@
       "source": [
         "run_config = extract_run_config(all_trials)\n",
         "run_config"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "d64f3dd2",
+      "metadata": {},
+      "source": [
+        "## SHAP feature importance\n",
+        "\n",
+        "After identifying the best model, use `compute_shap_values` to understand which features drive predictions. This requires the saved best model pickle files and the train/test splits."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "633b77a0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# load best model and train/test splits\n",
+        "best_model_type = all_trials.iloc[0][\"params.model\"]\n",
+        "best_model_path = os.path.join(experiment_folder, f\"{best_model_type}_best_model.pkl\")\n",
+        "with open(best_model_path, \"rb\") as f:\n",
+        "    best_model = pickle.load(f)\n",
+        "\n",
+        "train_val = pd.read_pickle(\n",
+        "    os.path.join(experiment_folder, \"../data_splits/train_val.pkl\")\n",
+        ")\n",
+        "test = pd.read_pickle(os.path.join(experiment_folder, \"../data_splits/test.pkl\"))\n",
+        "\n",
+        "shap_values = compute_shap_values(best_model, train_val, test)\n",
+        "shap_values"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e6ce56bd",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_shap_summary(shap_values, max_display=15)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "057fe581",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "plot_shap_bar(shap_values, max_display=15)"
       ]
     }
   ],

--- a/experiments/ritme_example_usage.ipynb
+++ b/experiments/ritme_example_usage.ipynb
@@ -3,20 +3,12 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "# Notebook displaying usage of the three main functionalities of *ritme*"
-      ]
+      "source": "# Notebook displaying usage of the four main functionalities of *ritme*"
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": [
-        "This notebook demonstrates how to use the three methods in `ritme` either in [a Python script](#python-api-example-usage) or through the [command line](#cli-example-usage). \n",
-        "\n",
-        "This demonstration uses example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/) and covers the **static** workflow (single time point per sample). For an overview of the **dynamic** workflow (temporal snapshotting with previous time points), see the [README](../README.md#dynamic-mode-temporal-snapshotting).\n",
-        "\n",
-        "To ensure a quick run time for demonstration purposes only the Linear Regression trainable is trained in this notebook (variable `ls_model_types` in the respective experiment configuration files)."
-      ]
+      "source": "This notebook demonstrates how to use the four methods in `ritme` either in [a Python script](#python-api-example-usage) or through the [command line](#cli-example-usage). \n\nThis demonstration uses example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/) and covers the **static** workflow (single time point per sample). For an overview of the **dynamic** workflow (temporal snapshotting with previous time points), see the [README](../README.md#dynamic-mode-temporal-snapshotting).\n\nTo ensure a quick run time for demonstration purposes only the Linear Regression trainable is trained in this notebook (variable `ls_model_types` in the respective experiment configuration files)."
     },
     {
       "cell_type": "markdown",
@@ -30,24 +22,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": [
-        "import os\n",
-        "import pandas as pd\n",
-        "import pickle\n",
-        "from ritme.evaluate_tuned_models import evaluate_tuned_models\n",
-        "from ritme.find_best_model_config import (\n",
-        "    _load_experiment_config,\n",
-        "    _load_phylogeny,\n",
-        "    _load_taxonomy,\n",
-        "    find_best_model_config,\n",
-        "    save_best_models,\n",
-        ")\n",
-        "from ritme.split_train_test import _load_data, split_train_test\n",
-        "\n",
-        "%load_ext autoreload\n",
-        "%autoreload 2\n",
-        "%matplotlib inline"
-      ]
+      "source": "import os\nimport pandas as pd\nimport pickle\nfrom ritme.evaluate_tuned_models import evaluate_tuned_models\nfrom ritme.explain_features import compute_shap_values, plot_shap_summary, plot_shap_bar\nfrom ritme.find_best_model_config import (\n    _load_experiment_config,\n    _load_phylogeny,\n    _load_taxonomy,\n    find_best_model_config,\n    save_best_models,\n)\nfrom ritme.split_train_test import _load_data, split_train_test\n\n%load_ext autoreload\n%autoreload 2\n%matplotlib inline"
     },
     {
       "cell_type": "markdown",
@@ -283,6 +258,32 @@
     {
       "cell_type": "markdown",
       "metadata": {},
+      "source": "### Explain feature importance with SHAP\n\nAfter evaluating the best models, you can use SHAP to understand which features drive predictions. `compute_shap_values` takes a single `TunedModel` and reuses the exact feature engineering pipeline learned during training."
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "best_model_type = \"linreg\"\nshap_values = compute_shap_values(best_model_dict[best_model_type], train_val, test)\nshap_values"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "plot_shap_summary(shap_values, max_display=15)"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "plot_shap_bar(shap_values, max_display=15)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
       "source": [
         "## CLI example usage"
       ]
@@ -331,6 +332,13 @@
         "! ritme evaluate-tuned-models \\\n",
         "  ritme_example_logs/example_linreg data_splits/train_val.pkl data_splits/test.pkl"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": "! ritme explain-features \\\n  ritme_example_logs/example_linreg linreg data_splits/train_val.pkl data_splits/test.pkl"
     },
     {
       "cell_type": "markdown",

--- a/experiments/ritme_example_usage.ipynb
+++ b/experiments/ritme_example_usage.ipynb
@@ -3,12 +3,20 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "# Notebook displaying usage of the four main functionalities of *ritme*"
+      "source": [
+        "# Notebook displaying usage of the four main functionalities of *ritme*"
+      ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "This notebook demonstrates how to use the four methods in `ritme` either in [a Python script](#python-api-example-usage) or through the [command line](#cli-example-usage). \n\nThis demonstration uses example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/) and covers the **static** workflow (single time point per sample). For an overview of the **dynamic** workflow (temporal snapshotting with previous time points), see the [README](../README.md#dynamic-mode-temporal-snapshotting).\n\nTo ensure a quick run time for demonstration purposes only the Linear Regression trainable is trained in this notebook (variable `ls_model_types` in the respective experiment configuration files)."
+      "source": [
+        "This notebook demonstrates how to use the four methods in `ritme` either in [a Python script](#python-api-example-usage) or through the [command line](#cli-example-usage). \n",
+        "\n",
+        "This demonstration uses example datasets from the [QIIME2 Moving Pictures tutorial](https://docs.qiime2.org/2024.10/tutorials/moving-pictures/) and covers the **static** workflow (single time point per sample). For an overview of the **dynamic** workflow (temporal snapshotting with previous time points), see the [README](../README.md#dynamic-mode-temporal-snapshotting).\n",
+        "\n",
+        "To ensure a quick run time for demonstration purposes only the Linear Regression trainable is trained in this notebook (variable `ls_model_types` in the respective experiment configuration files)."
+      ]
     },
     {
       "cell_type": "markdown",
@@ -22,7 +30,25 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "import os\nimport pandas as pd\nimport pickle\nfrom ritme.evaluate_tuned_models import evaluate_tuned_models\nfrom ritme.explain_features import compute_shap_values, plot_shap_summary, plot_shap_bar\nfrom ritme.find_best_model_config import (\n    _load_experiment_config,\n    _load_phylogeny,\n    _load_taxonomy,\n    find_best_model_config,\n    save_best_models,\n)\nfrom ritme.split_train_test import _load_data, split_train_test\n\n%load_ext autoreload\n%autoreload 2\n%matplotlib inline"
+      "source": [
+        "import os\n",
+        "import pandas as pd\n",
+        "import pickle\n",
+        "from ritme.evaluate_tuned_models import evaluate_tuned_models\n",
+        "from ritme.explain_features import compute_shap_values, plot_shap_summary, plot_shap_bar\n",
+        "from ritme.find_best_model_config import (\n",
+        "    _load_experiment_config,\n",
+        "    _load_phylogeny,\n",
+        "    _load_taxonomy,\n",
+        "    find_best_model_config,\n",
+        "    save_best_models,\n",
+        ")\n",
+        "from ritme.split_train_test import _load_data, split_train_test\n",
+        "\n",
+        "%load_ext autoreload\n",
+        "%autoreload 2\n",
+        "%matplotlib inline"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -258,28 +284,40 @@
     {
       "cell_type": "markdown",
       "metadata": {},
-      "source": "### Explain feature importance with SHAP\n\nAfter evaluating the best models, you can use SHAP to understand which features drive predictions. `compute_shap_values` takes a single `TunedModel` and reuses the exact feature engineering pipeline learned during training."
+      "source": [
+        "### Explain feature importance with SHAP\n",
+        "\n",
+        "After evaluating the best models, you can use SHAP to understand which features drive predictions. `compute_shap_values` takes a single `TunedModel` and reuses the exact feature engineering pipeline learned during training."
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "best_model_type = \"linreg\"\nshap_values = compute_shap_values(best_model_dict[best_model_type], train_val, test)\nshap_values"
+      "source": [
+        "best_model_type = \"linreg\"\n",
+        "shap_values = compute_shap_values(best_model_dict[best_model_type], train_val, test)\n",
+        "shap_values"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "plot_shap_summary(shap_values, max_display=15)"
+      "source": [
+        "plot_shap_summary(shap_values, max_display=15)"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "plot_shap_bar(shap_values, max_display=15)"
+      "source": [
+        "plot_shap_bar(shap_values, max_display=15)"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -338,7 +376,10 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "! ritme explain-features \\\n  ritme_example_logs/example_linreg linreg data_splits/train_val.pkl data_splits/test.pkl"
+      "source": [
+        "! ritme explain-features \\\n",
+        "  ritme_example_logs/example_linreg linreg data_splits/train_val.pkl data_splits/test.pkl"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -410,7 +451,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.12"
+      "version": "3.13.13"
     }
   },
   "nbformat": 4,

--- a/ritme/cli.py
+++ b/ritme/cli.py
@@ -1,6 +1,7 @@
 import typer
 
 from ritme.evaluate_tuned_models import cli_evaluate_tuned_models
+from ritme.explain_features import cli_explain_features
 from ritme.find_best_model_config import cli_find_best_model_config
 from ritme.split_train_test import cli_split_train_test
 
@@ -9,6 +10,7 @@ app = typer.Typer()
 app.command(name="split-train-test")(cli_split_train_test)
 app.command(name="find-best-model-config")(cli_find_best_model_config)
 app.command(name="evaluate-tuned-models")(cli_evaluate_tuned_models)
+app.command(name="explain-features")(cli_explain_features)
 
 if __name__ == "__main__":
     app()

--- a/ritme/evaluate_models.py
+++ b/ritme/evaluate_models.py
@@ -231,8 +231,13 @@ class TunedModel:
         other_ft_ls = self.snapshot_enriched_other_ft[time_label]
         return other_ft_ls, enriched
 
-    def predict(self, data: pd.DataFrame, split: str) -> Any:
-        """Run per-snapshot pipeline and predict."""
+    def build_design_matrix(self, data: pd.DataFrame, split: str) -> pd.DataFrame:
+        """Run per-snapshot feature engineering pipeline and return the design matrix.
+
+        This is the same pipeline used internally by ``predict`` but stops before
+        calling the underlying model, returning the processed feature DataFrame
+        instead.
+        """
         micro_ft_raw_all = [c for c in data.columns if c.startswith(self.ft_prefix)]
         self.time_labels = (
             _extract_time_labels(micro_ft_raw_all, self.ft_prefix)
@@ -315,6 +320,11 @@ class TunedModel:
             self.final_feature_cols = final_cols
         use_cols = self.final_feature_cols if split != "train" else final_cols
         X = accum.reindex(columns=use_cols, fill_value=0).fillna(np.nan).astype(float)
+        return X
+
+    def predict(self, data: pd.DataFrame, split: str) -> Any:
+        """Run per-snapshot pipeline and predict."""
+        X = self.build_design_matrix(data, split)
 
         if isinstance(self.model, NeuralNet):
             self.model.eval()

--- a/ritme/explain_features.py
+++ b/ritme/explain_features.py
@@ -97,7 +97,7 @@ def compute_shap_values(
         sv = explainer.shap_values(xgb.DMatrix(X_test))
         explanation = shap.Explanation(
             values=sv,
-            base_values=explainer.expected_value,
+            base_values=np.atleast_1d(explainer.expected_value),
             data=X_test.values,
             feature_names=X_test.columns.tolist(),
         )
@@ -105,7 +105,7 @@ def compute_shap_values(
         sv = explainer.shap_values(X_test.values)
         explanation = shap.Explanation(
             values=np.array(sv),
-            base_values=explainer.expected_value,
+            base_values=np.atleast_1d(explainer.expected_value),
             data=X_test.values,
             feature_names=X_test.columns.tolist(),
         )

--- a/ritme/explain_features.py
+++ b/ritme/explain_features.py
@@ -1,0 +1,245 @@
+import os
+import pickle
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import shap
+import torch
+import typer
+import xgboost as xgb
+
+from ritme._decorators import helper_function, main_function
+from ritme.evaluate_models import TunedModel, load_best_model
+from ritme.model_space.static_trainables import NeuralNet
+
+plt.rcParams.update({"font.family": "DejaVu Sans"})
+plt.style.use("seaborn-v0_8-pastel")
+
+
+@helper_function
+def _get_predict_fn(tmodel: TunedModel):
+    """Return a callable f(X_numpy) -> 1-D predictions for the underlying model."""
+    model = tmodel.model
+    if isinstance(model, NeuralNet):
+        device = next(model.parameters()).device
+
+        def _predict(X: np.ndarray) -> np.ndarray:
+            model.eval()
+            with torch.no_grad():
+                X_t = torch.tensor(X, dtype=torch.float32).to(device)
+                out = model(X_t)
+                out = model._prepare_predictions(out)
+                return out.detach().cpu().numpy().flatten()
+
+        return _predict
+    if isinstance(model, xgb.core.Booster):
+        return lambda X: model.predict(xgb.DMatrix(X)).flatten()
+    # sklearn-like (linreg, rf)
+    return lambda X: model.predict(X).flatten()
+
+
+@helper_function
+def _build_explainer(tmodel: TunedModel, X_background: pd.DataFrame) -> shap.Explainer:
+    """Build a SHAP explainer appropriate for the underlying model type."""
+    model = tmodel.model
+    if isinstance(model, dict):
+        raise TypeError(
+            "SHAP explanation is not supported for TRAC models. "
+            "TRAC coefficients already provide direct feature importance."
+        )
+    if isinstance(model, xgb.core.Booster):
+        return shap.TreeExplainer(model)
+    if isinstance(model, NeuralNet):
+        predict_fn = _get_predict_fn(tmodel)
+        return shap.KernelExplainer(predict_fn, X_background.values)
+    # sklearn tree-based or linear models
+    try:
+        return shap.Explainer(model, X_background)
+    except Exception:
+        predict_fn = _get_predict_fn(tmodel)
+        return shap.KernelExplainer(predict_fn, X_background.values)
+
+
+@main_function
+def compute_shap_values(
+    tmodel: TunedModel,
+    train_val: pd.DataFrame,
+    test: pd.DataFrame,
+    max_background_samples: int | None = None,
+) -> shap.Explanation:
+    """Compute SHAP values for the test set using a single trained model.
+
+    Args:
+        tmodel: A fitted TunedModel (must have been run on train split first).
+        train_val: Training data used as SHAP background.
+        test: Test data on which SHAP values are computed.
+        max_background_samples: If set, subsample the background to this many
+            rows (useful to speed up KernelExplainer for large datasets).
+            By default the full training set is used.
+
+    Returns:
+        shap.Explanation with .values, .base_values, .data, and .feature_names.
+    """
+    X_train = tmodel.build_design_matrix(train_val, split="train")
+    X_test = tmodel.build_design_matrix(test, split="test")
+
+    if max_background_samples is not None and max_background_samples < X_train.shape[0]:
+        X_bg = shap.sample(X_train, max_background_samples)
+    else:
+        X_bg = X_train
+
+    explainer = _build_explainer(tmodel, X_bg)
+
+    model = tmodel.model
+    if isinstance(model, xgb.core.Booster):
+        sv = explainer.shap_values(xgb.DMatrix(X_test))
+        explanation = shap.Explanation(
+            values=sv,
+            base_values=explainer.expected_value,
+            data=X_test.values,
+            feature_names=X_test.columns.tolist(),
+        )
+    elif isinstance(model, NeuralNet):
+        sv = explainer.shap_values(X_test.values)
+        explanation = shap.Explanation(
+            values=np.array(sv),
+            base_values=explainer.expected_value,
+            data=X_test.values,
+            feature_names=X_test.columns.tolist(),
+        )
+    else:
+        explanation = explainer(X_test)
+
+    return explanation
+
+
+@main_function
+def plot_shap_summary(
+    shap_values: shap.Explanation,
+    max_display: int = 20,
+    plot_type: str = "dot",
+    show: bool = True,
+) -> plt.Figure:
+    """Create a SHAP summary plot showing global feature importance.
+
+    Args:
+        shap_values: SHAP Explanation object from ``compute_shap_values``.
+        max_display: Maximum number of features to display.
+        plot_type: One of "dot", "bar", "violin".
+        show: Whether to display the plot immediately.
+
+    Returns:
+        The matplotlib Figure.
+    """
+    fig, ax = plt.subplots(1, 1, figsize=(10, max(6, max_display * 0.35)))
+    plt.sca(ax)
+    shap.summary_plot(
+        shap_values.values,
+        shap_values.data,
+        feature_names=shap_values.feature_names,
+        max_display=max_display,
+        plot_type=plot_type,
+        show=False,
+    )
+    plt.tight_layout()
+    if show:
+        plt.show()
+    return fig
+
+
+@main_function
+def plot_shap_bar(
+    shap_values: shap.Explanation,
+    max_display: int = 20,
+    show: bool = True,
+) -> plt.Figure:
+    """Create a SHAP bar plot of mean absolute SHAP values.
+
+    Args:
+        shap_values: SHAP Explanation object from ``compute_shap_values``.
+        max_display: Maximum number of features to display.
+        show: Whether to display the plot immediately.
+
+    Returns:
+        The matplotlib Figure.
+    """
+    fig, ax = plt.subplots(1, 1, figsize=(10, max(6, max_display * 0.35)))
+    plt.sca(ax)
+    shap.plots.bar(shap_values, max_display=max_display, show=False)
+    plt.tight_layout()
+    if show:
+        plt.show()
+    return fig
+
+
+# ----------------------------------------------------------------------------
+@main_function
+def cli_explain_features(
+    path_to_exp: str,
+    model_type: str,
+    path_to_train_val: str,
+    path_to_test: str,
+    max_display: int = 20,
+    max_background_samples: Optional[int] = None,
+) -> None:
+    """Compute SHAP feature importance for a single best tuned model.
+
+    Args:
+        path_to_exp: Path to the experiment directory containing
+            ``<model_type>_best_model.pkl``.
+        model_type: Model type to explain (e.g. "linreg", "rf", "xgb").
+        path_to_train_val: Path to the pickled train/validation DataFrame.
+        path_to_test: Path to the pickled test DataFrame.
+        max_display: Maximum number of features shown in plots.
+        max_background_samples: If set, subsample the SHAP background to this
+            many rows. By default the full training set is used.
+
+    Side Effects:
+        Writes into path_to_exp:
+            ``shap_values_<model_type>.pkl``,
+            ``shap_summary_<model_type>.png``,
+            ``shap_bar_<model_type>.png``.
+    """
+    train_val = pd.read_pickle(path_to_train_val)
+    test = pd.read_pickle(path_to_test)
+
+    tmodel = load_best_model(model_type, path_to_exp)
+
+    explanation = compute_shap_values(
+        tmodel,
+        train_val,
+        test,
+        max_background_samples=max_background_samples,
+    )
+
+    sv_path = os.path.join(path_to_exp, f"shap_values_{model_type}.pkl")
+    with open(sv_path, "wb") as f:
+        pickle.dump(explanation, f)
+    print(f"SHAP values saved in {sv_path}.")
+
+    fig_summary = plot_shap_summary(
+        explanation,
+        max_display=max_display,
+        show=False,
+    )
+    summary_path = os.path.join(path_to_exp, f"shap_summary_{model_type}.png")
+    fig_summary.savefig(summary_path, bbox_inches="tight")
+    plt.close(fig_summary)
+    print(f"SHAP summary plot saved in {summary_path}.")
+
+    fig_bar = plot_shap_bar(
+        explanation,
+        max_display=max_display,
+        show=False,
+    )
+    bar_path = os.path.join(path_to_exp, f"shap_bar_{model_type}.png")
+    fig_bar.savefig(bar_path, bbox_inches="tight")
+    plt.close(fig_bar)
+    print(f"SHAP bar plot saved in {bar_path}.")
+
+
+# ----------------------------------------------------------------------------
+if __name__ == "__main__":
+    typer.run(cli_explain_features)

--- a/ritme/tests/test_evaluate_models.py
+++ b/ritme/tests/test_evaluate_models.py
@@ -497,5 +497,103 @@ class TestTunedModelImplementation(unittest.TestCase):
         self.assertEqual(len(tuned.final_feature_cols), 4)
 
 
+class TestBuildDesignMatrix(unittest.TestCase):
+    def setUp(self):
+        current_dir = os.path.dirname(__file__)
+        self.data = pd.read_csv(
+            os.path.join(current_dir, "data/example_feature_table.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+        self.tax_df = pd.read_csv(
+            os.path.join(current_dir, "data/example_taxonomy.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+        self.data_config = {
+            "data_aggregation": None,
+            "data_transform": None,
+            "data_selection": None,
+            "data_enrich": None,
+            "data_enrich_with": None,
+        }
+        self.model = DummySklearnModel()
+        self.tmodel = TunedModel(
+            model=self.model,
+            data_config=self.data_config,
+            tax=self.tax_df,
+            path="/fake/path",
+        )
+
+    def test_returns_dataframe_with_correct_shape(self):
+        X = self.tmodel.build_design_matrix(self.data, split="train")
+        self.assertIsInstance(X, pd.DataFrame)
+        self.assertEqual(X.shape[0], self.data.shape[0])
+        self.assertGreater(X.shape[1], 0)
+
+    def test_output_matches_predict_input(self):
+        X = self.tmodel.build_design_matrix(self.data, split="train")
+        preds = self.tmodel.predict(self.data, split="train")
+        expected = np.max(X.values, axis=1).flatten()
+        assert_allclose(preds, expected, rtol=1e-6)
+
+    def test_train_test_column_consistency(self):
+        data_test = self.data.copy()
+        data_test.index = [f"T{i}" for i in range(1, 11)]
+        X_train = self.tmodel.build_design_matrix(self.data, split="train")
+        X_test = self.tmodel.build_design_matrix(data_test, split="test")
+        self.assertEqual(list(X_train.columns), list(X_test.columns))
+
+    def test_multi_snapshot(self):
+        df = pd.DataFrame(
+            {
+                "F0": [1.0, 2.0, 3.0],
+                "F1": [1.0, 1.0, 1.0],
+                "F0__t-1": [0.5, 1.5, 2.5],
+                "F1__t-1": [1.0, 1.0, 1.0],
+                "host": ["a", "b", "c"],
+                "host__t-1": ["a", "b", "c"],
+            },
+            index=["S1", "S2", "S3"],
+        )
+        tmodel = TunedModel(
+            model=self.model,
+            data_config=self.data_config,
+            tax=self.tax_df,
+            path="",
+        )
+        X = tmodel.build_design_matrix(df, split="train")
+        self.assertEqual(X.shape[0], 3)
+        self.assertEqual(X.shape[1], 4)
+        suffixed = [c for c in X.columns if "__t-1" in c]
+        self.assertEqual(len(suffixed), 2)
+
+    def test_sets_final_feature_cols_on_train(self):
+        self.assertEqual(self.tmodel.final_feature_cols, [])
+        self.tmodel.build_design_matrix(self.data, split="train")
+        self.assertGreater(len(self.tmodel.final_feature_cols), 0)
+
+    def test_with_full_feature_engineering(self):
+        cfg = {
+            "data_aggregation": "tax_class",
+            "data_transform": "alr",
+            "data_selection": "abundance_threshold",
+            "data_selection_t": 0.1,
+            "data_alr_denom_idx_map": {"t0": 0},
+            "data_enrich": "shannon_and_metadata",
+            "data_enrich_with": ["md2"],
+        }
+        tmodel = TunedModel(
+            model=self.model,
+            data_config=cfg,
+            tax=self.tax_df,
+            path="",
+        )
+        X = tmodel.build_design_matrix(self.data, split="train")
+        preds = tmodel.predict(self.data, split="train")
+        expected = np.max(X.values, axis=1).flatten()
+        assert_allclose(preds, expected, rtol=1e-6)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ritme/tests/test_explain_features.py
+++ b/ritme/tests/test_explain_features.py
@@ -1,0 +1,351 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import shap
+import xgboost as xgb
+from numpy.testing import assert_allclose
+
+from ritme.evaluate_models import TunedModel
+from ritme.explain_features import (
+    _build_explainer,
+    _get_predict_fn,
+    cli_explain_features,
+    compute_shap_values,
+    plot_shap_bar,
+    plot_shap_summary,
+)
+
+matplotlib.use("Agg")
+
+
+class DummySklearnModel:
+    def predict(self, X):
+        return np.sum(X, axis=1)
+
+    def fit(self, X, y):
+        return self
+
+
+class TestGetPredictFn(unittest.TestCase):
+    def test_sklearn_model(self):
+        model = DummySklearnModel()
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = model
+        fn = _get_predict_fn(tmodel)
+        X = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = fn(X)
+        assert_allclose(result, [3.0, 7.0])
+
+    def test_xgb_model(self):
+        X_train = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        y_train = np.array([1.0, 2.0, 3.0])
+        dtrain = xgb.DMatrix(X_train, label=y_train)
+        booster = xgb.train({"max_depth": 1, "verbosity": 0}, dtrain, num_boost_round=2)
+
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = booster
+        fn = _get_predict_fn(tmodel)
+        result = fn(X_train)
+        self.assertEqual(result.shape, (3,))
+
+
+class TestBuildExplainer(unittest.TestCase):
+    def test_trac_model_raises(self):
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = {"matrix_a": pd.DataFrame(), "model": pd.DataFrame()}
+        X_bg = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        with self.assertRaisesRegex(TypeError, "TRAC"):
+            _build_explainer(tmodel, X_bg)
+
+    def test_xgb_model_returns_tree_explainer(self):
+        X_train = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        y_train = np.array([1.0, 2.0, 3.0])
+        dtrain = xgb.DMatrix(X_train, label=y_train)
+        booster = xgb.train({"max_depth": 1, "verbosity": 0}, dtrain, num_boost_round=2)
+
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = booster
+        X_bg = pd.DataFrame(X_train, columns=["a", "b"])
+        explainer = _build_explainer(tmodel, X_bg)
+        self.assertIsInstance(explainer, shap.TreeExplainer)
+
+    def test_sklearn_model_returns_explainer(self):
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = DummySklearnModel()
+        X_bg = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        explainer = _build_explainer(tmodel, X_bg)
+        self.assertIsInstance(explainer, shap.Explainer)
+
+
+class TestBuildDesignMatrix(unittest.TestCase):
+    def setUp(self):
+        current_dir = os.path.dirname(__file__)
+        self.data = pd.read_csv(
+            os.path.join(current_dir, "data/example_feature_table.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+        self.tax_df = pd.read_csv(
+            os.path.join(current_dir, "data/example_taxonomy.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+        self.data_config = {
+            "data_aggregation": None,
+            "data_transform": None,
+            "data_selection": None,
+            "data_enrich": None,
+            "data_enrich_with": None,
+        }
+        self.model = DummySklearnModel()
+        self.tmodel = TunedModel(
+            model=self.model,
+            data_config=self.data_config,
+            tax=self.tax_df,
+            path="/fake/path",
+        )
+
+    def test_design_matrix_shape(self):
+        X = self.tmodel.build_design_matrix(self.data, split="train")
+        self.assertEqual(X.shape[0], self.data.shape[0])
+        self.assertGreater(X.shape[1], 0)
+
+    def test_design_matrix_matches_predict_input(self):
+        X = self.tmodel.build_design_matrix(self.data, split="train")
+        preds = self.tmodel.predict(self.data, split="train")
+        expected = np.sum(X.values, axis=1)
+        assert_allclose(preds, expected)
+
+    def test_design_matrix_train_test_consistency(self):
+        data_test = self.data.copy()
+        data_test.index = [f"T{i}" for i in range(1, 11)]
+        X_train = self.tmodel.build_design_matrix(self.data, split="train")
+        X_test = self.tmodel.build_design_matrix(data_test, split="test")
+        self.assertEqual(list(X_train.columns), list(X_test.columns))
+
+    def test_design_matrix_multi_snapshot(self):
+        df = pd.DataFrame(
+            {
+                "F0": [1.0, 2.0, 3.0],
+                "F1": [1.0, 1.0, 1.0],
+                "F0__t-1": [0.5, 1.5, 2.5],
+                "F1__t-1": [1.0, 1.0, 1.0],
+                "host": ["a", "b", "c"],
+                "host__t-1": ["a", "b", "c"],
+            },
+            index=["S1", "S2", "S3"],
+        )
+        tmodel = TunedModel(
+            model=self.model,
+            data_config=self.data_config,
+            tax=self.tax_df,
+            path="",
+        )
+        X = tmodel.build_design_matrix(df, split="train")
+        self.assertEqual(X.shape[0], 3)
+        # t0: F0, F1; t-1: F0__t-1, F1__t-1
+        self.assertEqual(X.shape[1], 4)
+        suffixed = [c for c in X.columns if "__t-1" in c]
+        self.assertEqual(len(suffixed), 2)
+
+
+class TestComputeShapValues(unittest.TestCase):
+    def setUp(self):
+        current_dir = os.path.dirname(__file__)
+        self.data = pd.read_csv(
+            os.path.join(current_dir, "data/example_feature_table.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+        self.tax_df = pd.read_csv(
+            os.path.join(current_dir, "data/example_taxonomy.tsv"),
+            sep="\t",
+            index_col=0,
+        )
+
+    def _make_tmodel_with_rf(self):
+        from sklearn.ensemble import RandomForestRegressor
+
+        data_config = {
+            "data_aggregation": None,
+            "data_transform": None,
+            "data_selection": None,
+            "data_enrich": None,
+            "data_enrich_with": None,
+        }
+        tmodel = TunedModel(
+            model=RandomForestRegressor(n_estimators=5, random_state=42),
+            data_config=data_config,
+            tax=self.tax_df,
+            path="",
+        )
+        X = tmodel.build_design_matrix(self.data, split="train")
+        y = np.arange(X.shape[0], dtype=float)
+        tmodel.model.fit(X.values, y)
+        return tmodel
+
+    def test_compute_shap_values_rf(self):
+        tmodel = self._make_tmodel_with_rf()
+        train = self.data.iloc[:7]
+        test = self.data.iloc[7:]
+        explanation = compute_shap_values(tmodel, train, test)
+        self.assertIsInstance(explanation, shap.Explanation)
+        self.assertEqual(explanation.values.shape[0], test.shape[0])
+        self.assertEqual(len(explanation.feature_names), len(tmodel.final_feature_cols))
+
+    def test_compute_shap_values_xgb(self):
+        data_config = {
+            "data_aggregation": None,
+            "data_transform": None,
+            "data_selection": None,
+            "data_enrich": None,
+            "data_enrich_with": None,
+        }
+        tmodel = TunedModel(
+            model=None, data_config=data_config, tax=self.tax_df, path=""
+        )
+        X_train = tmodel.build_design_matrix(self.data, split="train")
+        y_train = np.arange(X_train.shape[0], dtype=float)
+        dtrain = xgb.DMatrix(X_train, label=y_train)
+        booster = xgb.train({"max_depth": 2, "verbosity": 0}, dtrain, num_boost_round=5)
+        tmodel.model = booster
+
+        train = self.data.iloc[:7]
+        test = self.data.iloc[7:]
+        explanation = compute_shap_values(tmodel, train, test)
+        self.assertIsInstance(explanation, shap.Explanation)
+        self.assertEqual(explanation.values.shape[0], test.shape[0])
+
+    def test_trac_model_raises(self):
+        tmodel = MagicMock(spec=TunedModel)
+        tmodel.model = {"matrix_a": pd.DataFrame(), "model": pd.DataFrame()}
+        X_bg = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        tmodel.build_design_matrix.return_value = X_bg
+        with self.assertRaises(TypeError):
+            compute_shap_values(tmodel, X_bg, X_bg)
+
+    def test_max_background_samples(self):
+        tmodel = self._make_tmodel_with_rf()
+        train = self.data.iloc[:7]
+        test = self.data.iloc[7:]
+        explanation = compute_shap_values(tmodel, train, test, max_background_samples=3)
+        self.assertIsInstance(explanation, shap.Explanation)
+
+
+class TestPlotShapSummary(unittest.TestCase):
+    def _make_explanation(self):
+        values = np.random.RandomState(42).randn(10, 3)
+        data = np.random.RandomState(42).randn(10, 3)
+        return shap.Explanation(
+            values=values,
+            base_values=np.zeros(10),
+            data=data,
+            feature_names=["feat_a", "feat_b", "feat_c"],
+        )
+
+    def test_plot_shap_summary_returns_figure(self):
+        explanation = self._make_explanation()
+        fig = plot_shap_summary(explanation, show=False)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_plot_shap_summary_bar_type(self):
+        explanation = self._make_explanation()
+        fig = plot_shap_summary(explanation, plot_type="bar", show=False)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_plot_shap_bar_returns_figure(self):
+        explanation = self._make_explanation()
+        fig = plot_shap_bar(explanation, show=False)
+        self.assertIsInstance(fig, plt.Figure)
+        plt.close(fig)
+
+
+class TestCliExplainFeatures(unittest.TestCase):
+    @patch("ritme.explain_features.plot_shap_bar")
+    @patch("ritme.explain_features.plot_shap_summary")
+    @patch("ritme.explain_features.compute_shap_values")
+    @patch("ritme.explain_features.load_best_model")
+    @patch("pandas.read_pickle")
+    def test_cli_saves_outputs(
+        self,
+        mock_read_pickle,
+        mock_load_best_model,
+        mock_compute_shap_values,
+        mock_plot_summary,
+        mock_plot_bar,
+    ):
+        train_val = pd.DataFrame({"F1": [1, 2, 3], "target": [4, 5, 6]})
+        test = pd.DataFrame({"F1": [7, 8], "target": [9, 10]})
+        mock_read_pickle.side_effect = [train_val, test]
+
+        mock_tmodel = MagicMock(spec=TunedModel)
+        mock_tmodel.model = DummySklearnModel()
+        mock_load_best_model.return_value = mock_tmodel
+
+        mock_explanation = shap.Explanation(
+            values=np.array([[1.0, 2.0]]),
+            base_values=np.array([0.0]),
+            data=np.array([[3.0, 4.0]]),
+            feature_names=["a", "b"],
+        )
+        mock_compute_shap_values.return_value = mock_explanation
+
+        mock_plot_summary.return_value = plt.figure()
+        mock_plot_bar.return_value = plt.figure()
+
+        with tempfile.TemporaryDirectory() as path_to_exp:
+            with patch("builtins.print") as mock_print:
+                cli_explain_features(path_to_exp, "rf", "train.pkl", "test.pkl")
+
+            expected_calls = [
+                call(f"SHAP values saved in {path_to_exp}/shap_values_rf.pkl."),
+                call(f"SHAP summary plot saved in {path_to_exp}/shap_summary_rf.png."),
+                call(f"SHAP bar plot saved in {path_to_exp}/shap_bar_rf.png."),
+            ]
+            mock_print.assert_has_calls(expected_calls)
+
+            self.assertTrue(
+                os.path.exists(os.path.join(path_to_exp, "shap_values_rf.pkl"))
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(path_to_exp, "shap_summary_rf.png"))
+            )
+            self.assertTrue(
+                os.path.exists(os.path.join(path_to_exp, "shap_bar_rf.png"))
+            )
+        plt.close("all")
+
+    @patch("ritme.explain_features.compute_shap_values")
+    @patch("ritme.explain_features.load_best_model")
+    @patch("pandas.read_pickle")
+    def test_cli_trac_raises(
+        self,
+        mock_read_pickle,
+        mock_load_best_model,
+        mock_compute_shap_values,
+    ):
+        train_val = pd.DataFrame({"F1": [1, 2]})
+        test = pd.DataFrame({"F1": [3, 4]})
+        mock_read_pickle.side_effect = [train_val, test]
+
+        mock_tmodel = MagicMock(spec=TunedModel)
+        mock_tmodel.model = {"matrix_a": pd.DataFrame(), "model": pd.DataFrame()}
+        mock_load_best_model.return_value = mock_tmodel
+
+        mock_compute_shap_values.side_effect = TypeError("TRAC")
+
+        with tempfile.TemporaryDirectory() as path_to_exp:
+            with self.assertRaises(TypeError):
+                cli_explain_features(path_to_exp, "trac", "train.pkl", "test.pkl")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds built-in SHAP (SHapley Additive exPlanations) support for interpreting top features of best tuned models. It includes:

**New module `ritme/explain_features.py`** with Python API and CLI:
- `compute_shap_values(tmodel, train_val, test)` — computes SHAP values on a test set for a single trained model, using the model's exact feature engineering pipeline to build the design matrix. Supports sklearn (linreg, rf), XGBoost, and neural network models. TRAC models raise a `TypeError` (their coefficients already provide direct feature importance).
- `plot_shap_summary` — creates a SHAP dot/bar/violin summary plot of global feature importance.
- `plot_shap_bar` — creates a mean |SHAP| bar plot.
- `cli_explain_features(path_to_exp, model_type, ...)` — CLI wrapper (`ritme explain-features`) that loads a single best model from an experiment directory, computes SHAP values, and saves plots and pickled SHAP values.

**Refactored `TunedModel.build_design_matrix`** (in `evaluate_models.py`):
- Extracted the feature engineering pipeline from `TunedModel.predict` into a new public method `build_design_matrix` that returns the processed feature DataFrame without calling the underlying model. This enables SHAP explainers to operate on the exact same design matrix used for prediction.
- `predict` now delegates to `build_design_matrix` internally — no behavioral change.

### Changes
- `ritme/evaluate_models.py` — refactored `predict` to use new `build_design_matrix` method
- `ritme/explain_features.py` — new module with SHAP computation, plotting, and CLI wrapper
- `ritme/cli.py` — registered `explain-features` command
- `ritme/tests/test_explain_features.py` — unit tests covering `build_design_matrix`, SHAP computation (rf, xgb, trac-error), explainer construction, predict functions, plotting, and CLI wrapper
- `ritme/tests/test_evaluate_models.py` — unit tests for `build_design_matrix`
- `README.md` — added `compute_shap_values` to usage table; added "Explain feature importance" section with Python API and CLI examples
- `AGENTS.md` — updated key modules table and CLI/API pattern table
- `experiments/ritme_example_usage.ipynb` — added SHAP section (Python API + CLI)
- `experiments/evaluate_trials_mlflow.ipynb` — added SHAP feature importance section
- `experiments/g_mi_3_evaluate.ipynb` — updated WIP SHAP section to use the new `ritme.explain_features` API
