### PR TITLE
FIX: Logging bottleneck by optimizing XGB & NN trial checkpoint writes

### DIFF
--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -1,5 +1,6 @@
 """Module with tune trainables of all static models"""
 
+import math
 import os
 import pickle
 import random
@@ -539,6 +540,19 @@ def load_data(X_train, y_train, X_val, y_val, config, seed_model):
 
 
 class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
+    """PyTorch Lightning callback that decouples metric reports from checkpoint writes.
+
+    Reports metrics to Ray Tune after every validation epoch (so the ASHA
+    scheduler can prune trials and intermediate progress is logged), but only
+    writes a checkpoint to disk when ``rmse_val`` improves over the best one
+    seen so far. ``on_train_end`` writes a final guarantee checkpoint so that
+    every trial -- even one killed by the time budget mid-training -- ends with
+    at least one checkpoint on disk for downstream model retrieval.
+
+    Also injects ``nb_features`` into every reported metric dict (used by
+    ``evaluate_models.py``).
+    """
+
     def __init__(
         self,
         metrics: Optional[Union[str, List[str], Dict[str, str]]] = None,
@@ -546,24 +560,70 @@ class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
         save_checkpoints: bool = True,
         on: Union[str, List[str]] = "validation_end",
         nb_features: int = None,
+        score_attr: str = "rmse_val",
+        score_mode: str = "min",
     ):
         super().__init__(
             metrics=metrics, filename=filename, save_checkpoints=save_checkpoints, on=on
         )
         self.nb_features = nb_features
+        if score_mode not in ("min", "max"):
+            raise ValueError(f"score_mode must be 'min' or 'max', got {score_mode!r}")
+        self._score_attr = score_attr
+        self._score_mode = score_mode
+        self._best_score = float("inf") if score_mode == "min" else float("-inf")
+        self._wrote_any_checkpoint = False
+
+    def _is_improvement(self, score) -> bool:
+        if score is None:
+            return False
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            return False
+        if math.isnan(score):
+            return False
+        if self._score_mode == "min":
+            return score < self._best_score
+        return score > self._best_score
+
+    def _build_report_dict(self, trainer, pl_module):
+        report_dict = self._get_report_dict(trainer, pl_module)
+        if not report_dict:
+            return None
+        report_dict["nb_features"] = self.nb_features
+        return report_dict
 
     def _handle(self, trainer: Trainer, pl_module: LightningModule):
-        # CUSTOM: includes also nb_features in report
         if trainer.sanity_checking:
             return
 
-        report_dict = self._get_report_dict(trainer, pl_module)
-        report_dict["nb_features"] = self.nb_features
-        if not report_dict:
+        report_dict = self._build_report_dict(trainer, pl_module)
+        if report_dict is None:
             return
 
+        score = report_dict.get(self._score_attr)
+        if self._is_improvement(score):
+            self._best_score = score
+            with self._get_checkpoint(trainer) as checkpoint:
+                tune.report(report_dict, checkpoint=checkpoint)
+            self._wrote_any_checkpoint = True
+        else:
+            tune.report(report_dict)
+
+    def on_train_end(self, trainer, pl_module):
+        # Final-checkpoint guarantee: only writes if no improvement-gated
+        # checkpoint was ever produced (e.g. when training reports NaN loss
+        # for every epoch). CheckpointConfig will discard this if a better
+        # one already exists.
+        if self._wrote_any_checkpoint:
+            return
+        report_dict = self._build_report_dict(trainer, pl_module)
+        if report_dict is None:
+            return
         with self._get_checkpoint(trainer) as checkpoint:
             tune.report(report_dict, checkpoint=checkpoint)
+        self._wrote_any_checkpoint = True
 
 
 def train_nn(
@@ -657,7 +717,7 @@ def train_nn(
                 "loss_train": "train_loss",
             },
             filename="checkpoint",
-            on="train_end",
+            on="validation_end",
             nb_features=X_train.shape[1],
         ),
         EarlyStopping(
@@ -757,6 +817,68 @@ def add_nb_features_to_results(results, nb_features):
     return results
 
 
+class _RitmeXGBCheckpointCallback(xgb_cc):
+    """XGBoost callback that decouples metric reporting from checkpoint writes.
+
+    Reports metrics to Ray Tune on every boosting iteration so the ASHA
+    scheduler always has fresh data to prune trials, but only writes a
+    checkpoint to disk when the validation score improves over the best one
+    seen so far. The Ray ``CheckpointConfig(num_to_keep=1, ...)`` in
+    ``tune_models.py`` keeps the highest-scoring checkpoint, so any extra final
+    checkpoint with a worse score (e.g. from ``checkpoint_at_end=True``) is
+    discarded automatically.
+
+    This avoids the per-iteration disk I/O bottleneck that the previous
+    ``frequency=1`` setting caused (Ray Tune's experiment-state snapshotting
+    couldn't keep up with the write rate).
+    """
+
+    def __init__(
+        self,
+        metrics,
+        filename,
+        results_postprocessing_fn,
+        score_attr,
+        score_mode,
+    ):
+        super().__init__(
+            metrics=metrics,
+            filename=filename,
+            frequency=0,
+            checkpoint_at_end=True,
+            results_postprocessing_fn=results_postprocessing_fn,
+        )
+        if score_mode not in ("min", "max"):
+            raise ValueError(f"score_mode must be 'min' or 'max', got {score_mode!r}")
+        self._score_attr = score_attr
+        self._score_mode = score_mode
+        self._best_score = float("inf") if score_mode == "min" else float("-inf")
+
+    def _is_improvement(self, score) -> bool:
+        if score is None:
+            return False
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            return False
+        if math.isnan(score):
+            return False
+        if self._score_mode == "min":
+            return score < self._best_score
+        return score > self._best_score
+
+    def after_iteration(self, model, epoch, evals_log):
+        self._evals_log = evals_log
+        report_dict = self._get_report_dict(evals_log)
+        score = report_dict.get(self._score_attr)
+        if self._is_improvement(score):
+            self._best_score = score
+            self._last_checkpoint_iteration = epoch
+            self._save_and_report_checkpoint(report_dict, model)
+        else:
+            self._report_metrics(report_dict)
+
+
 def custom_xgb_metric(
     predt: np.ndarray, dtrain: xgb.DMatrix
 ) -> List[Tuple[str, float]]:
@@ -815,10 +937,9 @@ def train_xgb(
 
     _save_taxonomy(tax)
     # ! model
-    # Initialize the checkpoint callback - which is built-in support for xgb
-    # models in Ray Tune
-    checkpoint_callback = xgb_cc(
-        # tune:xgboost
+    # Decoupled metric/checkpoint reporting: per-iteration metrics for ASHA,
+    # checkpoint writes only on validation improvement.
+    checkpoint_callback = _RitmeXGBCheckpointCallback(
         metrics={
             "r2_train": "train-r2",
             "r2_val": "val-r2",
@@ -829,7 +950,8 @@ def train_xgb(
         results_postprocessing_fn=lambda results: add_nb_features_to_results(
             results, X_train.shape[1]
         ),
-        frequency=1,
+        score_attr="rmse_val",
+        score_mode="min",
     )
     patience = max(10, int(0.1 * config["n_estimators"]))
     xgb.train(

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -4,6 +4,8 @@ import math
 import os
 import pickle
 import random
+import shutil
+import tempfile
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import joblib
@@ -543,11 +545,21 @@ class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
     """PyTorch Lightning callback that decouples metric reports from checkpoint writes.
 
     Reports metrics to Ray Tune after every validation epoch (so the ASHA
-    scheduler can prune trials and intermediate progress is logged), but only
-    writes a checkpoint to disk when ``rmse_val`` improves over the best one
-    seen so far. ``on_train_end`` writes a final guarantee checkpoint so that
-    every trial -- even one killed by the time budget mid-training -- ends with
-    at least one checkpoint on disk for downstream model retrieval.
+    scheduler can prune trials and intermediate progress is logged), and writes
+    **at most two** Ray Tune checkpoints per trial:
+
+    1. A safety write on the *first* validation improvement, so trials that
+       are paused-then-killed by HyperBand still have at least one checkpoint
+       on disk (otherwise ``result.checkpoint`` is ``None`` and downstream
+       retrieval crashes).
+    2. A final write in ``on_train_end`` containing the best validation state
+       seen during the run -- score-based retention by ``CheckpointConfig``
+       keeps the better of the two.
+
+    Improvements *between* the first and the last are saved to a per-trial
+    scratch directory only (no ``tune.report(checkpoint=...)`` call), so the
+    experiment-state snapshotter is not triggered for them. Bounding writes to
+    two per trial keeps it from being saturated by concurrent trials.
 
     Also injects ``nb_features`` into every reported metric dict (used by
     ``evaluate_models.py``).
@@ -572,7 +584,15 @@ class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
         self._score_attr = score_attr
         self._score_mode = score_mode
         self._best_score = float("inf") if score_mode == "min" else float("-inf")
-        self._wrote_any_checkpoint = False
+        # Per-trial scratch dir holding the best Lightning checkpoint seen so
+        # far. Lazily created on first improvement; cleaned up at on_train_end
+        # after the contents have been reported to Ray Tune.
+        self._best_scratch_dir: Optional[str] = None
+        self._best_report_dict: Optional[Dict] = None
+        # Tracks whether the first-improvement safety checkpoint has been
+        # written. Used so we only pay the Ray Tune write cost once during
+        # training (before the second write at on_train_end).
+        self._wrote_safety_checkpoint = False
 
     def _is_improvement(self, score) -> bool:
         if score is None:
@@ -594,6 +614,11 @@ class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
         report_dict["nb_features"] = self.nb_features
         return report_dict
 
+    def _ensure_scratch_dir(self) -> str:
+        if self._best_scratch_dir is None:
+            self._best_scratch_dir = tempfile.mkdtemp(prefix="ritme_nn_best_")
+        return self._best_scratch_dir
+
     def _handle(self, trainer: Trainer, pl_module: LightningModule):
         if trainer.sanity_checking:
             return
@@ -603,27 +628,42 @@ class NNTuneReportCheckpointCallback(TuneReportCheckpointCallback):
             return
 
         score = report_dict.get(self._score_attr)
-        if self._is_improvement(score):
+        improved = self._is_improvement(score)
+        if improved:
             self._best_score = score
-            with self._get_checkpoint(trainer) as checkpoint:
-                tune.report(report_dict, checkpoint=checkpoint)
-            self._wrote_any_checkpoint = True
+            scratch_dir = self._ensure_scratch_dir()
+            # Overwrite previous best on local disk (no Ray Tune visibility).
+            trainer.save_checkpoint(os.path.join(scratch_dir, self._filename))
+            self._best_report_dict = dict(report_dict)
+
+        if improved and not self._wrote_safety_checkpoint:
+            # Safety write: ensure paused-then-killed trials have a checkpoint.
+            self._wrote_safety_checkpoint = True
+            checkpoint = ray.train.Checkpoint.from_directory(self._best_scratch_dir)
+            tune.report(report_dict, checkpoint=checkpoint)
         else:
+            # Cheap metric-only report so ASHA can prune.
             tune.report(report_dict)
 
     def on_train_end(self, trainer, pl_module):
-        # Final-checkpoint guarantee: only writes if no improvement-gated
-        # checkpoint was ever produced (e.g. when training reports NaN loss
-        # for every epoch). CheckpointConfig will discard this if a better
-        # one already exists.
-        if self._wrote_any_checkpoint:
+        # Final write of the best validation state seen during training.
+        if self._best_scratch_dir is not None and self._best_report_dict is not None:
+            checkpoint = ray.train.Checkpoint.from_directory(self._best_scratch_dir)
+            tune.report(self._best_report_dict, checkpoint=checkpoint)
+            # Ray Tune copies the checkpoint contents synchronously into its
+            # storage during tune.report, so the scratch dir is safe to remove.
+            shutil.rmtree(self._best_scratch_dir, ignore_errors=True)
+            self._best_scratch_dir = None
             return
-        report_dict = self._build_report_dict(trainer, pl_module)
-        if report_dict is None:
-            return
+
+        # Fallback: no improvement was ever recorded (e.g. NaN loss every
+        # epoch). Persist the current trainer state so downstream retrieval
+        # still works.
+        report_dict = self._build_report_dict(trainer, pl_module) or {
+            "nb_features": self.nb_features
+        }
         with self._get_checkpoint(trainer) as checkpoint:
             tune.report(report_dict, checkpoint=checkpoint)
-        self._wrote_any_checkpoint = True
 
 
 def train_nn(
@@ -821,16 +861,25 @@ class _RitmeXGBCheckpointCallback(xgb_cc):
     """XGBoost callback that decouples metric reporting from checkpoint writes.
 
     Reports metrics to Ray Tune on every boosting iteration so the ASHA
-    scheduler always has fresh data to prune trials, but only writes a
-    checkpoint to disk when the validation score improves over the best one
-    seen so far. The Ray ``CheckpointConfig(num_to_keep=1, ...)`` in
-    ``tune_models.py`` keeps the highest-scoring checkpoint, so any extra final
-    checkpoint with a worse score (e.g. from ``checkpoint_at_end=True``) is
-    discarded automatically.
+    scheduler always has fresh data to prune trials, and writes **at most two**
+    Ray Tune checkpoints per trial:
 
-    This avoids the per-iteration disk I/O bottleneck that the previous
-    ``frequency=1`` setting caused (Ray Tune's experiment-state snapshotting
-    couldn't keep up with the write rate).
+    1. A safety write on the *first* validation improvement, so trials that
+       are paused-then-killed by HyperBand still have at least one checkpoint
+       on disk (otherwise ``result.checkpoint`` is ``None`` and downstream
+       retrieval crashes).
+    2. A final write in ``after_training`` containing the best booster seen
+       during the run -- score-based retention by ``CheckpointConfig`` keeps
+       the better of the two.
+
+    Improvements *between* the first and the last are held in memory only
+    (``Booster.save_raw`` returns a compact UBJSON bytearray), so per-iteration
+    disk I/O stays at zero. Bounding writes to two per trial keeps the
+    experiment-state snapshotter from being saturated by concurrent trials.
+
+    Parent's ``checkpoint_at_end`` handling is disabled because it would
+    persist the *last* iteration's state, which for trials that overfit early
+    is worse than the best historical state we track in-memory.
     """
 
     def __init__(
@@ -845,7 +894,7 @@ class _RitmeXGBCheckpointCallback(xgb_cc):
             metrics=metrics,
             filename=filename,
             frequency=0,
-            checkpoint_at_end=True,
+            checkpoint_at_end=False,
             results_postprocessing_fn=results_postprocessing_fn,
         )
         if score_mode not in ("min", "max"):
@@ -853,6 +902,14 @@ class _RitmeXGBCheckpointCallback(xgb_cc):
         self._score_attr = score_attr
         self._score_mode = score_mode
         self._best_score = float("inf") if score_mode == "min" else float("-inf")
+        # In-memory snapshot of the best booster seen so far. ``save_raw`` is
+        # cheap (a few KB to a few MB) and avoids per-iteration disk I/O.
+        self._best_model_bytes: Optional[bytearray] = None
+        self._best_report_dict: Optional[Dict] = None
+        # Tracks whether the first-improvement safety checkpoint has been
+        # written. Used so we only pay the Ray Tune write cost once during
+        # training (before the second write at after_training).
+        self._wrote_safety_checkpoint = False
 
     def _is_improvement(self, score) -> bool:
         if score is None:
@@ -871,12 +928,35 @@ class _RitmeXGBCheckpointCallback(xgb_cc):
         self._evals_log = evals_log
         report_dict = self._get_report_dict(evals_log)
         score = report_dict.get(self._score_attr)
-        if self._is_improvement(score):
+        improved = self._is_improvement(score)
+        if improved:
             self._best_score = score
-            self._last_checkpoint_iteration = epoch
+            # Snapshot the booster state in-memory (no disk I/O).
+            self._best_model_bytes = model.save_raw(raw_format="ubj")
+            self._best_report_dict = dict(report_dict)
+
+        if improved and not self._wrote_safety_checkpoint:
+            # Safety write: ensure paused-then-killed trials have a checkpoint.
+            self._wrote_safety_checkpoint = True
             self._save_and_report_checkpoint(report_dict, model)
         else:
+            # Cheap metric-only report so ASHA can prune.
             self._report_metrics(report_dict)
+
+    def after_training(self, model):
+        # Final write of the best booster seen during training.
+        if self._best_model_bytes is not None:
+            best_booster = xgb.Booster()
+            best_booster.load_model(bytearray(self._best_model_bytes))
+            self._save_and_report_checkpoint(self._best_report_dict, best_booster)
+            return model
+
+        # Fallback: no improvement was ever recorded (e.g. NaN val-rmse for
+        # every iteration). Persist the current model state so downstream
+        # retrieval still works.
+        report_dict = self._get_report_dict(self._evals_log) if self._evals_log else {}
+        self._save_and_report_checkpoint(report_dict, model)
+        return model
 
 
 def custom_xgb_metric(

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -1,6 +1,7 @@
 """Testing static trainables"""
 
 import os
+import shutil
 import tempfile
 import unittest
 from unittest.mock import MagicMock, call, patch
@@ -580,10 +581,17 @@ class TestTrainableLogging(unittest.TestCase):
 class TestRitmeXGBCheckpointCallback(unittest.TestCase):
     """Unit tests for the decoupled XGBoost callback.
 
-    The callback must report metrics on every iteration (cheap, in-memory) but
-    only write a checkpoint when ``rmse_val`` improves over the best seen so
-    far. This avoids the per-iteration disk I/O bottleneck while keeping the
-    ASHA scheduler fed with intermediate metrics.
+    The callback reports metrics on every iteration (cheap, in-memory) but
+    only writes Ray Tune checkpoints at two points per trial:
+
+    1. On the *first* validation improvement (safety write so paused-then-killed
+       HyperBand trials still have a checkpoint).
+    2. At end of training (final write of the best booster seen).
+
+    Improvements between the first and the last are held in-memory only. This
+    bounds checkpoint writes to two per trial -- combined with ``num_to_keep=3``
+    in ``tune_models.py`` it keeps the experiment-state snapshotter from being
+    saturated by concurrent trials.
     """
 
     def _make_callback(self):
@@ -632,78 +640,129 @@ class TestRitmeXGBCheckpointCallback(unittest.TestCase):
                 score_mode="invalid",
             )
 
-    def test_metric_reported_every_iteration_checkpoint_only_on_improvement(self):
+    def test_after_iteration_writes_safety_checkpoint_only_on_first_improvement(self):
+        # Hybrid: exactly one Ray Tune checkpoint write during iteration (the
+        # first improvement). All other improvements are in-memory only.
+        # _report_metrics is called every non-write iteration so ASHA can prune.
         callback = self._make_callback()
         model = MagicMock()
+        # save_raw is called on improvements; return distinct payloads so we
+        # can assert in-memory snapshot was updated to the *latest* improvement.
+        model.save_raw.side_effect = [bytearray(b"snap0"), bytearray(b"snap2")]
 
-        # Improvement schedule: iter 0 (any < inf is improvement), 2, 4 only.
-        # The other iters report worse-or-equal val-rmse.
-        val_rmses = [0.50, 0.52, 0.40, 0.45, 0.30, 0.35]
+        val_rmses = [0.50, 0.52, 0.40, 0.45]  # improvements at 0 and 2
         train_rmses = [0.40] * len(val_rmses)
-        improvements = {0, 2, 4}
 
         with patch.object(
             callback, "_save_and_report_checkpoint"
         ) as mock_save, patch.object(callback, "_report_metrics") as mock_report:
             for epoch in range(len(val_rmses)):
-                evals_log = self._evals_log(
-                    train_rmses[: epoch + 1], val_rmses[: epoch + 1]
+                callback.after_iteration(
+                    model,
+                    epoch,
+                    self._evals_log(train_rmses[: epoch + 1], val_rmses[: epoch + 1]),
                 )
-                callback.after_iteration(model, epoch, evals_log)
 
-        # Every iteration produces exactly one report (either with or without
-        # a checkpoint).
-        total_reports = mock_save.call_count + mock_report.call_count
-        self.assertEqual(total_reports, len(val_rmses))
+        # Exactly one Ray Tune checkpoint write -- on the first improvement.
+        mock_save.assert_called_once()
+        first_call_dict = mock_save.call_args.args[0]
+        self.assertEqual(first_call_dict["rmse_val"], 0.50)
+        self.assertEqual(first_call_dict["nb_features"], 7)
+        # Remaining iterations report metrics only (cheap, no checkpoint).
+        self.assertEqual(mock_report.call_count, len(val_rmses) - 1)
+        # In-memory best snapshot updated on every improvement (2 total).
+        self.assertEqual(model.save_raw.call_count, 2)
+        self.assertEqual(callback._best_score, 0.40)
+        self.assertEqual(callback._best_model_bytes, bytearray(b"snap2"))
+        self.assertEqual(callback._best_report_dict["nb_features"], 7)
+        # Safety-write flag flipped exactly once.
+        self.assertTrue(callback._wrote_safety_checkpoint)
+        # Reported metric dicts always carry nb_features (postprocessing fn).
+        for c in mock_report.call_args_list:
+            self.assertEqual(c.args[0]["nb_features"], 7)
+            self.assertIn("rmse_val", c.args[0])
 
-        # Checkpoints fire only on improvements.
-        self.assertEqual(mock_save.call_count, len(improvements))
-        self.assertEqual(mock_report.call_count, len(val_rmses) - len(improvements))
-
-        # The dicts passed always carry the renamed key plus nb_features
-        # (set by the postprocessing fn).
-        for save_call in mock_save.call_args_list:
-            report_dict = save_call.args[0]
-            self.assertIn("rmse_val", report_dict)
-            self.assertEqual(report_dict["nb_features"], 7)
-        for report_call in mock_report.call_args_list:
-            report_dict = report_call.args[0]
-            self.assertIn("rmse_val", report_dict)
-            self.assertEqual(report_dict["nb_features"], 7)
-
-        # Best score tracked correctly.
-        self.assertEqual(callback._best_score, 0.30)
-
-    def test_first_iteration_always_checkpoints(self):
-        # Initial _best_score is +inf so the very first finite score must
-        # qualify as an improvement; this guarantees at least one checkpoint
-        # exists per trial.
+    def test_after_training_writes_final_checkpoint_from_in_memory_best(self):
         callback = self._make_callback()
         model = MagicMock()
-        with patch.object(callback, "_save_and_report_checkpoint") as mock_save:
+        model.save_raw.return_value = bytearray(b"best_state")
+
+        # Patch _save_and_report_checkpoint and _report_metrics across both
+        # the iteration loop and the after_training call so the iter-0 safety
+        # write is captured (and doesn't try to call into Ray Tune).
+        with patch.object(
+            callback, "_save_and_report_checkpoint"
+        ) as mock_save, patch.object(callback, "_report_metrics"):
+            # One improvement at iter 0 (safety write), then no improvement.
             callback.after_iteration(model, 0, self._evals_log([0.4], [0.5]))
+            callback.after_iteration(model, 1, self._evals_log([0.4, 0.4], [0.5, 0.6]))
+
+            # Patch booster construction so we can verify it's loaded from
+            # the in-memory snapshot, then handed to _save_and_report_checkpoint.
+            loaded_booster = MagicMock()
+            with patch(
+                "ritme.model_space.static_trainables.xgb.Booster",
+                return_value=loaded_booster,
+            ) as mock_booster_cls:
+                callback.after_training(model)
+
+        # Two Ray Tune checkpoint writes total: safety write + final write.
+        self.assertEqual(mock_save.call_count, 2)
+        # Safety write (iter 0): handed the *current* booster, val-rmse=0.5.
+        first_dict, first_model = mock_save.call_args_list[0].args
+        self.assertEqual(first_dict["rmse_val"], 0.5)
+        self.assertIs(first_model, model)
+        # Final write (after_training): reconstructed booster from in-memory
+        # bytes, with the *best* report dict.
+        mock_booster_cls.assert_called_once_with()
+        loaded_booster.load_model.assert_called_once_with(bytearray(b"best_state"))
+        last_dict, last_model = mock_save.call_args_list[1].args
+        self.assertEqual(last_dict["rmse_val"], 0.5)
+        self.assertEqual(last_dict["nb_features"], 7)
+        self.assertIs(last_model, loaded_booster)
+
+    def test_after_training_falls_back_when_no_improvement_recorded(self):
+        # If no iteration ever recorded an improvement (e.g. NaN scores
+        # throughout), the callback must still emit a checkpoint at end so
+        # downstream retrieval works.
+        callback = self._make_callback()
+        model = MagicMock()
+        # Drive one iteration with NaN so _evals_log gets stored.
+        with patch.object(callback, "_report_metrics"):
+            callback.after_iteration(
+                model, 0, self._evals_log([float("nan")], [float("nan")])
+            )
+        self.assertIsNone(callback._best_model_bytes)
+
+        with patch.object(callback, "_save_and_report_checkpoint") as mock_save:
+            callback.after_training(model)
         mock_save.assert_called_once()
+        # Falls back to writing the *current* model, not a reloaded best.
+        self.assertIs(mock_save.call_args.args[1], model)
 
     def test_nan_score_does_not_qualify_as_improvement(self):
         callback = self._make_callback()
         model = MagicMock()
-        with patch.object(
-            callback, "_save_and_report_checkpoint"
-        ) as mock_save, patch.object(callback, "_report_metrics") as mock_report:
+        with patch.object(callback, "_report_metrics") as mock_report:
             callback.after_iteration(
                 model, 0, self._evals_log([float("nan")], [float("nan")])
             )
-        mock_save.assert_not_called()
+        # No in-memory snapshot taken on NaN.
+        model.save_raw.assert_not_called()
+        self.assertIsNone(callback._best_model_bytes)
+        # But metrics are still reported every iter.
         mock_report.assert_called_once()
 
 
 class TestNNTuneReportCheckpointCallback(unittest.TestCase):
     """Unit tests for the decoupled PyTorch Lightning callback.
 
-    Verifies that ``_handle`` calls Ray Tune's report on every invocation but
-    only opens a checkpoint context when ``rmse_val`` improves, and that
-    ``on_train_end`` writes a guarantee checkpoint when no improvement-gated
-    write ever happened.
+    Verifies that ``_handle`` reports metrics on every call (so ASHA can
+    prune), persists Lightning checkpoints on every improvement to a per-trial
+    scratch dir, and writes Ray Tune checkpoints at exactly two points per
+    trial: a safety write on the *first* improvement (so paused-then-killed
+    HyperBand trials still have a checkpoint) and a final write at
+    ``on_train_end`` of the best validation state seen.
     """
 
     def _make_callback(self):
@@ -731,62 +790,109 @@ class TestNNTuneReportCheckpointCallback(unittest.TestCase):
         }
         return trainer
 
-    def test_handle_reports_every_call_checkpoints_only_on_improvement(self):
+    def test_handle_writes_safety_checkpoint_only_on_first_improvement(self):
         callback = self._make_callback()
-        # Schedule of validation rmses: improvement at calls 0, 2; calls 1, 3, 4
-        # are non-improvements.
         val_rmses = [0.5, 0.6, 0.4, 0.45, 0.42]
-        improvements = {0, 2}
+        improvements = {0, 2}  # 0.5 < inf; 0.4 < 0.5
 
-        ckpt_cm = MagicMock()
-        ckpt_cm.__enter__ = MagicMock(return_value="fake_checkpoint")
-        ckpt_cm.__exit__ = MagicMock(return_value=False)
-        with patch.object(
-            callback, "_get_checkpoint", return_value=ckpt_cm
-        ) as mock_ckpt, patch(
+        # Track which trainers had save_checkpoint called.
+        trainers = [self._trainer_with_score(v) for v in val_rmses]
+
+        ckpt_path = (
+            "ritme.model_space.static_trainables.ray.train" ".Checkpoint.from_directory"
+        )
+        with patch(ckpt_path, return_value="fake_safety_ckpt") as mock_from_dir, patch(
             "ritme.model_space.static_trainables.tune.report"
         ) as mock_report:
-            for v in val_rmses:
-                callback._handle(self._trainer_with_score(v), MagicMock())
+            for trainer in trainers:
+                callback._handle(trainer, MagicMock())
 
-        # _get_checkpoint (the disk-write context) only opens on improvements.
-        self.assertEqual(mock_ckpt.call_count, len(improvements))
-        # tune.report is called every time.
+        # tune.report is called every iteration.
         self.assertEqual(mock_report.call_count, len(val_rmses))
 
-        # Reports on improvement carry a checkpoint kwarg; reports without
-        # improvement do not.
+        # Exactly one call carries a Ray Tune checkpoint kwarg -- the very
+        # first improvement (idx 0). The other 4 calls are metric-only.
         with_ckpt = [
-            c for c in mock_report.call_args_list if c.kwargs.get("checkpoint")
+            i
+            for i, c in enumerate(mock_report.call_args_list)
+            if "checkpoint" in c.kwargs
         ]
-        without_ckpt = [
-            c for c in mock_report.call_args_list if not c.kwargs.get("checkpoint")
-        ]
-        self.assertEqual(len(with_ckpt), len(improvements))
-        self.assertEqual(len(without_ckpt), len(val_rmses) - len(improvements))
+        self.assertEqual(with_ckpt, [0])
+        self.assertEqual(
+            mock_report.call_args_list[0].kwargs["checkpoint"], "fake_safety_ckpt"
+        )
+        # ``ray.train.Checkpoint.from_directory`` was invoked exactly once
+        # during _handle (the safety write).
+        mock_from_dir.assert_called_once()
 
-        # nb_features is injected into every report dict.
-        for c in mock_report.call_args_list:
-            self.assertEqual(c.args[0]["nb_features"], 11)
+        # Every report dict carries nb_features.
+        for report_call in mock_report.call_args_list:
+            self.assertEqual(report_call.args[0]["nb_features"], 11)
 
-        self.assertTrue(callback._wrote_any_checkpoint)
+        # trainer.save_checkpoint is called only on improvements (per-trial
+        # scratch-dir snapshots, no Ray Tune visibility).
+        save_calls = [i for i, t in enumerate(trainers) if t.save_checkpoint.called]
+        self.assertEqual(set(save_calls), improvements)
+
+        # State after run.
         self.assertEqual(callback._best_score, 0.4)
+        self.assertIsNotNone(callback._best_scratch_dir)
+        self.assertIsNotNone(callback._best_report_dict)
+        self.assertEqual(callback._best_report_dict["rmse_val"], 0.4)
+        self.assertTrue(callback._wrote_safety_checkpoint)
+
+        # Cleanup: scratch dir was created on disk.
+        if callback._best_scratch_dir and os.path.isdir(callback._best_scratch_dir):
+            shutil.rmtree(callback._best_scratch_dir, ignore_errors=True)
 
     def test_sanity_checking_short_circuits(self):
         callback = self._make_callback()
         trainer = self._trainer_with_score(0.1)
         trainer.sanity_checking = True
-        with patch(
-            "ritme.model_space.static_trainables.tune.report"
-        ) as mock_report, patch.object(callback, "_get_checkpoint") as mock_ckpt:
+        with patch("ritme.model_space.static_trainables.tune.report") as mock_report:
             callback._handle(trainer, MagicMock())
         mock_report.assert_not_called()
-        mock_ckpt.assert_not_called()
+        trainer.save_checkpoint.assert_not_called()
+        self.assertIsNone(callback._best_scratch_dir)
 
-    def test_on_train_end_writes_guarantee_checkpoint_when_none_yet(self):
+    def test_on_train_end_reports_best_from_scratch_dir(self):
+        callback = self._make_callback()
+        # Simulate one prior improvement: scratch dir exists, best dict set.
+        scratch = tempfile.mkdtemp(prefix="ritme_nn_best_test_")
+        callback._best_scratch_dir = scratch
+        callback._best_report_dict = {"rmse_val": 0.4, "nb_features": 11}
+        try:
+            ckpt_path = (
+                "ritme.model_space.static_trainables.ray.train"
+                ".Checkpoint.from_directory"
+            )
+            with patch(
+                ckpt_path, return_value="fake_checkpoint"
+            ) as mock_from_dir, patch(
+                "ritme.model_space.static_trainables.tune.report"
+            ) as mock_report:
+                callback.on_train_end(self._trainer_with_score(0.99), MagicMock())
+            mock_from_dir.assert_called_once_with(scratch)
+            mock_report.assert_called_once()
+            # Reported dict is the *best* one tracked, not the trainer's
+            # current state, and the Ray checkpoint is attached.
+            self.assertEqual(mock_report.call_args.args[0]["rmse_val"], 0.4)
+            self.assertEqual(
+                mock_report.call_args.kwargs.get("checkpoint"), "fake_checkpoint"
+            )
+            # Scratch dir is cleaned up after the report.
+            self.assertFalse(os.path.isdir(scratch))
+            self.assertIsNone(callback._best_scratch_dir)
+        finally:
+            if os.path.isdir(scratch):
+                shutil.rmtree(scratch, ignore_errors=True)
+
+    def test_on_train_end_falls_back_when_no_improvement_recorded(self):
+        # No prior improvement: must still report a checkpoint built from the
+        # current trainer state so downstream retrieval works.
         callback = self._make_callback()
         ckpt_cm = MagicMock()
-        ckpt_cm.__enter__ = MagicMock(return_value="fake_checkpoint")
+        ckpt_cm.__enter__ = MagicMock(return_value="fallback_checkpoint")
         ckpt_cm.__exit__ = MagicMock(return_value=False)
         with patch.object(
             callback, "_get_checkpoint", return_value=ckpt_cm
@@ -796,15 +902,6 @@ class TestNNTuneReportCheckpointCallback(unittest.TestCase):
             callback.on_train_end(self._trainer_with_score(0.7), MagicMock())
         mock_ckpt.assert_called_once()
         mock_report.assert_called_once()
-        self.assertTrue(callback._wrote_any_checkpoint)
-
-    def test_on_train_end_skips_when_checkpoint_already_written(self):
-        callback = self._make_callback()
-        # Simulate that an earlier validation_end already wrote a checkpoint.
-        callback._wrote_any_checkpoint = True
-        with patch.object(callback, "_get_checkpoint") as mock_ckpt, patch(
-            "ritme.model_space.static_trainables.tune.report"
-        ) as mock_report:
-            callback.on_train_end(self._trainer_with_score(0.7), MagicMock())
-        mock_ckpt.assert_not_called()
-        mock_report.assert_not_called()
+        self.assertEqual(
+            mock_report.call_args.kwargs.get("checkpoint"), "fallback_checkpoint"
+        )

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -293,7 +293,7 @@ class TestTrainables(unittest.TestCase):
     @patch("ritme.model_space.static_trainables.process_train")
     @patch("ritme.model_space.static_trainables.xgb.DMatrix")
     @patch("ritme.model_space.static_trainables.xgb.train")
-    @patch("ritme.model_space.static_trainables.xgb_cc")
+    @patch("ritme.model_space.static_trainables._RitmeXGBCheckpointCallback")
     def test_train_xgb(
         self,
         mock_checkpoint,
@@ -575,3 +575,236 @@ class TestTrainableLogging(unittest.TestCase):
                     self.assertAlmostEqual(
                         logged_rmse[split], calculated_rmse, places=6
                     )
+
+
+class TestRitmeXGBCheckpointCallback(unittest.TestCase):
+    """Unit tests for the decoupled XGBoost callback.
+
+    The callback must report metrics on every iteration (cheap, in-memory) but
+    only write a checkpoint when ``rmse_val`` improves over the best seen so
+    far. This avoids the per-iteration disk I/O bottleneck while keeping the
+    ASHA scheduler fed with intermediate metrics.
+    """
+
+    def _make_callback(self):
+        return st._RitmeXGBCheckpointCallback(
+            metrics={
+                "r2_train": "train-r2",
+                "r2_val": "val-r2",
+                "rmse_train": "train-rmse",
+                "rmse_val": "val-rmse",
+            },
+            filename="checkpoint",
+            results_postprocessing_fn=lambda r: st.add_nb_features_to_results(r, 7),
+            score_attr="rmse_val",
+            score_mode="min",
+        )
+
+    def _evals_log(self, train_rmses, val_rmses):
+        from collections import OrderedDict
+
+        # XGBoost passes evals_log[set_name][metric_name] = list of historical
+        # values; the callback reads the last entry of each list as "current".
+        return OrderedDict(
+            [
+                (
+                    "train",
+                    OrderedDict(
+                        [("r2", [0.0] * len(train_rmses)), ("rmse", list(train_rmses))]
+                    ),
+                ),
+                (
+                    "val",
+                    OrderedDict(
+                        [("r2", [0.0] * len(val_rmses)), ("rmse", list(val_rmses))]
+                    ),
+                ),
+            ]
+        )
+
+    def test_invalid_score_mode_raises(self):
+        with self.assertRaises(ValueError):
+            st._RitmeXGBCheckpointCallback(
+                metrics={"rmse_val": "val-rmse"},
+                filename="checkpoint",
+                results_postprocessing_fn=lambda r: r,
+                score_attr="rmse_val",
+                score_mode="invalid",
+            )
+
+    def test_metric_reported_every_iteration_checkpoint_only_on_improvement(self):
+        callback = self._make_callback()
+        model = MagicMock()
+
+        # Improvement schedule: iter 0 (any < inf is improvement), 2, 4 only.
+        # The other iters report worse-or-equal val-rmse.
+        val_rmses = [0.50, 0.52, 0.40, 0.45, 0.30, 0.35]
+        train_rmses = [0.40] * len(val_rmses)
+        improvements = {0, 2, 4}
+
+        with patch.object(
+            callback, "_save_and_report_checkpoint"
+        ) as mock_save, patch.object(callback, "_report_metrics") as mock_report:
+            for epoch in range(len(val_rmses)):
+                evals_log = self._evals_log(
+                    train_rmses[: epoch + 1], val_rmses[: epoch + 1]
+                )
+                callback.after_iteration(model, epoch, evals_log)
+
+        # Every iteration produces exactly one report (either with or without
+        # a checkpoint).
+        total_reports = mock_save.call_count + mock_report.call_count
+        self.assertEqual(total_reports, len(val_rmses))
+
+        # Checkpoints fire only on improvements.
+        self.assertEqual(mock_save.call_count, len(improvements))
+        self.assertEqual(mock_report.call_count, len(val_rmses) - len(improvements))
+
+        # The dicts passed always carry the renamed key plus nb_features
+        # (set by the postprocessing fn).
+        for save_call in mock_save.call_args_list:
+            report_dict = save_call.args[0]
+            self.assertIn("rmse_val", report_dict)
+            self.assertEqual(report_dict["nb_features"], 7)
+        for report_call in mock_report.call_args_list:
+            report_dict = report_call.args[0]
+            self.assertIn("rmse_val", report_dict)
+            self.assertEqual(report_dict["nb_features"], 7)
+
+        # Best score tracked correctly.
+        self.assertEqual(callback._best_score, 0.30)
+
+    def test_first_iteration_always_checkpoints(self):
+        # Initial _best_score is +inf so the very first finite score must
+        # qualify as an improvement; this guarantees at least one checkpoint
+        # exists per trial.
+        callback = self._make_callback()
+        model = MagicMock()
+        with patch.object(callback, "_save_and_report_checkpoint") as mock_save:
+            callback.after_iteration(model, 0, self._evals_log([0.4], [0.5]))
+        mock_save.assert_called_once()
+
+    def test_nan_score_does_not_qualify_as_improvement(self):
+        callback = self._make_callback()
+        model = MagicMock()
+        with patch.object(
+            callback, "_save_and_report_checkpoint"
+        ) as mock_save, patch.object(callback, "_report_metrics") as mock_report:
+            callback.after_iteration(
+                model, 0, self._evals_log([float("nan")], [float("nan")])
+            )
+        mock_save.assert_not_called()
+        mock_report.assert_called_once()
+
+
+class TestNNTuneReportCheckpointCallback(unittest.TestCase):
+    """Unit tests for the decoupled PyTorch Lightning callback.
+
+    Verifies that ``_handle`` calls Ray Tune's report on every invocation but
+    only opens a checkpoint context when ``rmse_val`` improves, and that
+    ``on_train_end`` writes a guarantee checkpoint when no improvement-gated
+    write ever happened.
+    """
+
+    def _make_callback(self):
+        return st.NNTuneReportCheckpointCallback(
+            metrics={
+                "rmse_val": "val_rmse",
+                "rmse_train": "train_rmse",
+            },
+            filename="checkpoint",
+            on="validation_end",
+            nb_features=11,
+        )
+
+    def _trainer_with_score(self, val_rmse):
+        trainer = MagicMock()
+        trainer.sanity_checking = False
+        # _get_report_dict reads trainer.callback_metrics[metric].item()
+        train_metric = MagicMock()
+        train_metric.item.return_value = 0.42
+        val_metric = MagicMock()
+        val_metric.item.return_value = val_rmse
+        trainer.callback_metrics = {
+            "val_rmse": val_metric,
+            "train_rmse": train_metric,
+        }
+        return trainer
+
+    def test_handle_reports_every_call_checkpoints_only_on_improvement(self):
+        callback = self._make_callback()
+        # Schedule of validation rmses: improvement at calls 0, 2; calls 1, 3, 4
+        # are non-improvements.
+        val_rmses = [0.5, 0.6, 0.4, 0.45, 0.42]
+        improvements = {0, 2}
+
+        ckpt_cm = MagicMock()
+        ckpt_cm.__enter__ = MagicMock(return_value="fake_checkpoint")
+        ckpt_cm.__exit__ = MagicMock(return_value=False)
+        with patch.object(
+            callback, "_get_checkpoint", return_value=ckpt_cm
+        ) as mock_ckpt, patch(
+            "ritme.model_space.static_trainables.tune.report"
+        ) as mock_report:
+            for v in val_rmses:
+                callback._handle(self._trainer_with_score(v), MagicMock())
+
+        # _get_checkpoint (the disk-write context) only opens on improvements.
+        self.assertEqual(mock_ckpt.call_count, len(improvements))
+        # tune.report is called every time.
+        self.assertEqual(mock_report.call_count, len(val_rmses))
+
+        # Reports on improvement carry a checkpoint kwarg; reports without
+        # improvement do not.
+        with_ckpt = [
+            c for c in mock_report.call_args_list if c.kwargs.get("checkpoint")
+        ]
+        without_ckpt = [
+            c for c in mock_report.call_args_list if not c.kwargs.get("checkpoint")
+        ]
+        self.assertEqual(len(with_ckpt), len(improvements))
+        self.assertEqual(len(without_ckpt), len(val_rmses) - len(improvements))
+
+        # nb_features is injected into every report dict.
+        for c in mock_report.call_args_list:
+            self.assertEqual(c.args[0]["nb_features"], 11)
+
+        self.assertTrue(callback._wrote_any_checkpoint)
+        self.assertEqual(callback._best_score, 0.4)
+
+    def test_sanity_checking_short_circuits(self):
+        callback = self._make_callback()
+        trainer = self._trainer_with_score(0.1)
+        trainer.sanity_checking = True
+        with patch(
+            "ritme.model_space.static_trainables.tune.report"
+        ) as mock_report, patch.object(callback, "_get_checkpoint") as mock_ckpt:
+            callback._handle(trainer, MagicMock())
+        mock_report.assert_not_called()
+        mock_ckpt.assert_not_called()
+
+    def test_on_train_end_writes_guarantee_checkpoint_when_none_yet(self):
+        callback = self._make_callback()
+        ckpt_cm = MagicMock()
+        ckpt_cm.__enter__ = MagicMock(return_value="fake_checkpoint")
+        ckpt_cm.__exit__ = MagicMock(return_value=False)
+        with patch.object(
+            callback, "_get_checkpoint", return_value=ckpt_cm
+        ) as mock_ckpt, patch(
+            "ritme.model_space.static_trainables.tune.report"
+        ) as mock_report:
+            callback.on_train_end(self._trainer_with_score(0.7), MagicMock())
+        mock_ckpt.assert_called_once()
+        mock_report.assert_called_once()
+        self.assertTrue(callback._wrote_any_checkpoint)
+
+    def test_on_train_end_skips_when_checkpoint_already_written(self):
+        callback = self._make_callback()
+        # Simulate that an earlier validation_end already wrote a checkpoint.
+        callback._wrote_any_checkpoint = True
+        with patch.object(callback, "_get_checkpoint") as mock_ckpt, patch(
+            "ritme.model_space.static_trainables.tune.report"
+        ) as mock_report:
+            callback.on_train_end(self._trainer_with_score(0.7), MagicMock())
+        mock_ckpt.assert_not_called()
+        mock_report.assert_not_called()

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -316,7 +316,14 @@ def run_trials(
             checkpoint_config=tune.CheckpointConfig(
                 checkpoint_score_attribute=metric,
                 checkpoint_score_order=mode,
-                num_to_keep=1,
+                # num_to_keep=3 lets the trainable callbacks write up to 2
+                # checkpoints per trial (a first-improvement safety checkpoint
+                # plus a final best-state checkpoint) without ever reaching
+                # Ray Tune's "force experiment-state snapshot every num_to_keep
+                # checkpoints per trial" threshold. Each forced snapshot is a
+                # cluster-wide sync; with 5 concurrent trials this used to
+                # produce visible bottleneck warnings (see ritme#84).
+                num_to_keep=3,
             ),
             callbacks=callbacks,
         ),


### PR DESCRIPTION
This PR closes #84 & potentially improves #88. Decouples per-iteration metric reporting from
checkpoint writes for both XGBoost and Neural Network trainables, capping
checkpoint writes at **two per trial** so the Ray Tune experiment-state
snapshotter is no longer saturated by concurrent trials.

## What changed

- **`ritme/model_space/static_trainables.py`** -- new
  `_RitmeXGBCheckpointCallback` (XGB) and rewritten
  `NNTuneReportCheckpointCallback` (NN). Both now:
  1. Report metrics to Ray Tune on every iteration / validation epoch
     (cheap, no checkpoint kwarg) so ASHA / HyperBand always have fresh
     scores to act on.
  2. Write a Ray Tune checkpoint exactly once during training, on the
     **first validation improvement** -- a safety write so trials that
     get paused-then-killed by HyperBand still have a checkpoint on disk
     (otherwise `result.checkpoint == None` and downstream retrieval
     crashes; this is the bug PR #83 introduced for NN).
  3. Track the best model in-memory (XGB: `Booster.save_raw()` bytearray;
     NN: per-trial scratch dir written via `trainer.save_checkpoint`)
     across all subsequent improvements -- no Ray Tune visibility, no
     snapshot trigger.
  4. Write a final Ray Tune checkpoint at `after_training` /
     `on_train_end` containing the best state seen. Score-based retention
     by `CheckpointConfig` keeps it as the latest checkpoint.

- **`ritme/tune_models.py`** -- bumped
  `CheckpointConfig(num_to_keep=1 -> 3)`. Ray Tune forces an
  experiment-state snapshot whenever any trial reaches `num_to_keep`
  checkpoint writes since the last snapshot; with the callbacks now
  capped at 2 writes per trial, `num_to_keep=3` ensures that threshold
  is never crossed by per-trial writes alone, eliminating concurrent
  snapshot bursts.

- **`ritme/tests/test_model_static_trainables.py`** -- new unit tests
  for both callbacks covering: (a) exactly one safety write on first
  improvement, (b) every iteration reports metrics, (c) in-memory /
  scratch-dir best snapshot updates on every improvement, (d) final
  write at end-of-training reconstructs the best state, (e) NaN-score
  guarding, (f) fallback when no improvement was ever recorded.

## Why this works

Ray Tune's snapshot warning fires when an experiment-state snapshot is
forced repeatedly within 5s. With `num_to_keep=N`, snapshot is forced
once any trial has written N checkpoints since the last snapshot. Bounding
writes per trial to 2 and setting `num_to_keep=3` means the per-trial
threshold is never reached -- the only snapshots are the periodic ones
(default 10s). Concurrent trials no longer cluster snapshot triggers.

Best-model retrieval is unaffected: `CheckpointConfig(num_to_keep=3,
checkpoint_score_attribute="rmse_val")` keeps up to 3 checkpoints per
trial (only the 1-2 we write), with the latest write being the best
state. `result.checkpoint.to_directory()` in [evaluate_models.py:43]
returns that latest checkpoint.

## Comparison of trials completed & warnings

All runs: `fully_reproducible=true` (HyperBand), `max_concurrent_trials=5`,
`time_budget_s=120`, `target=month`, same `train_val.pkl`.

### XGB only (`ls_model_types=["xgb"]`)

| Metric | Before (`main`) | After (this PR) |
|---|---|---|
| Snapshotting bottleneck warnings | 1511 | **0** |
| Trials completed (unique TERMINATED) | 16 | **18** |
| `xgb_best_model.pkl` downstream load | OK | OK |

### NN only (`ls_model_types=["nn_reg"]`)

| Metric | Before (`main`) | After (this PR) |
|---|---|---|
| Snapshotting bottleneck warnings | 0 (but see below) | **0** |
| Trials completed (unique TERMINATED) | crash | **5** |
| Training iterations per trial | N/A (crash) | **7-9** (per-epoch) |
| `nn_reg_best_model.pkl` downstream load | crash (`No best trial found for rmse_val`) | OK |

The `main` NN has zero snapshot warnings because PR #83 changed the callback
to `on="train_end"`, which only fires once at the end of `trainer.fit()`.
With HyperBand pausing/killing trials before `train_end` fires, no metrics
are reported at all, so the run crashes when trying to find the best trial.
This PR restores `on="validation_end"` so metrics are reported per epoch
(ASHA can prune), adds the safety write so paused-then-killed trials have a
checkpoint, and writes the final best checkpoint at `on_train_end`.
