### PR TITLE
ENH: Improve parallelization of XGB & NN trainables

### DIFF
--- a/.github/workflows/build_n_upload_package.yml
+++ b/.github/workflows/build_n_upload_package.yml
@@ -7,19 +7,24 @@ on:
 jobs:
   build-conda-package:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       TZ: 'UTC'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # necessary for versioneer to derive the package version from git tags
+          fetch-depth: 0
       - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: 'latest'
-          auto-update-conda: true
           activate-environment: build-env
           python-version: '3.10'
       - name: Install conda-build and anaconda-client
-        run: conda install -n build-env -y mamba conda-build anaconda-client
+        run: conda install -n build-env -y conda-build anaconda-client
       - name: Build Conda Package
         id: build
         run: |
@@ -29,13 +34,13 @@ jobs:
 
           # Capture the package path without building
           PACKAGE_PATH=$(conda run -n build-env conda build --no-test \
-            -c conda-forge -c bioconda -c pytorch -c defaults \
+            -c conda-forge \
             --croot $CONDA_BUILD_ROOT \
             ci/recipe --output)
 
           # Build the package using the specified build root
           conda run -n build-env conda build --no-test \
-            -c conda-forge -c bioconda -c pytorch -c defaults \
+            -c conda-forge \
             --croot $CONDA_BUILD_ROOT \
             ci/recipe
 
@@ -47,4 +52,4 @@ jobs:
           ANACONDA_USER: adamova
         run: |
           # Upload the built package using the captured path
-          conda run -n build-env anaconda upload "${{ steps.build.outputs.package_path }}" --user $ANACONDA_USER
+          conda run -n build-env anaconda upload --force "${{ steps.build.outputs.package_path }}" --user $ANACONDA_USER

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - importlib-metadata
     - conda-forge::ipywidgets
     - lightning
-    - mlflow
+    - mlflow >=2.0
     - nbformat
     - numpy
     - optuna

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -135,6 +135,8 @@ def train_linreg(
     seed_model: int,
     tax: pd.DataFrame = pd.DataFrame(),
     tree_phylo: skbio.TreeNode = skbio.TreeNode(),
+    cpus_per_trial: int = 1,
+    gpus_per_trial: int = 0,
 ) -> None:
     """
     Train a linear regression model and report the results to Ray Tune.
@@ -231,6 +233,8 @@ def train_trac(
     seed_model: int,
     tax: pd.DataFrame,
     tree_phylo: skbio.TreeNode,
+    cpus_per_trial: int = 1,
+    gpus_per_trial: int = 0,
 ) -> None:
     """
     Train a trac model and report the results to Ray Tune.
@@ -292,6 +296,8 @@ def train_rf(
     seed_model: int,
     tax: pd.DataFrame = pd.DataFrame(),
     tree_phylo: skbio.TreeNode = skbio.TreeNode(),
+    cpus_per_trial: int = 1,
+    gpus_per_trial: int = 0,
 ) -> None:
     """
     Train a random forest model and report the results to Ray Tune.
@@ -303,6 +309,7 @@ def train_rf(
     host_id (str): The host ID.
     seed_data (int): The seed for the data.
     seed_model (int): The seed for the model.
+    cpus_per_trial (int): Number of CPUs allocated by Ray Tune for this trial.
 
     Returns:
     None
@@ -324,9 +331,7 @@ def train_rf(
         max_features=config["max_features"],
         min_impurity_decrease=config["min_impurity_decrease"],
         bootstrap=config["bootstrap"],
-        # ray tune uses joblib for parallelization - so this makes sure all
-        # available resources are used
-        n_jobs=None,
+        n_jobs=cpus_per_trial,
         # set randomness
         random_state=seed_model,
     )
@@ -507,7 +512,7 @@ def seed_worker(worker_id):
     random.seed(worker_seed)
 
 
-def load_data(X_train, y_train, X_val, y_val, config, seed_model):
+def load_data(X_train, y_train, X_val, y_val, config, seed_model, num_workers=2):
     # fixed data loader - for reference on reproducibility:
     # https://docs.pytorch.org/docs/stable/notes/randomness.html
 
@@ -527,14 +532,14 @@ def load_data(X_train, y_train, X_val, y_val, config, seed_model):
         train_dataset,
         batch_size=config["batch_size"],
         shuffle=True,
-        num_workers=2,
+        num_workers=num_workers,
         worker_init_fn=seed_worker,
         generator=g,
     )
     val_loader = DataLoader(
         val_dataset,
         batch_size=config["batch_size"],
-        num_workers=2,
+        num_workers=num_workers,
         worker_init_fn=seed_worker,
         generator=g,
     )
@@ -676,7 +681,12 @@ def train_nn(
     seed_model,
     stratify_by,
     nn_type="regression",
+    cpus_per_trial=1,
+    gpus_per_trial=0,
 ):
+    # Limit PyTorch threads to Ray-allocated CPUs to avoid oversubscription
+    torch.set_num_threads(cpus_per_trial)
+
     # Force deterministic algorithms and disable benchmark
     torch.use_deterministic_algorithms(True)
     torch.backends.cudnn.deterministic = True
@@ -693,8 +703,10 @@ def train_nn(
         config, train_val, target, host_id, tax, seed_data, stratify_by=stratify_by
     )
 
+    # Scale DataLoader workers to allocated CPUs (reserve at least 1 for training)
+    num_workers = max(0, cpus_per_trial - 1)
     train_loader, val_loader = load_data(
-        X_train, y_train, X_val, y_val, config, seed_model
+        X_train, y_train, X_val, y_val, config, seed_model, num_workers=num_workers
     )
 
     # Model
@@ -789,6 +801,8 @@ def train_nn_reg(
     seed_model,
     tax,
     tree_phylo,
+    cpus_per_trial=1,
+    gpus_per_trial=0,
 ):
     train_nn(
         config,
@@ -800,6 +814,8 @@ def train_nn_reg(
         seed_model,
         stratify_by,
         nn_type="regression",
+        cpus_per_trial=cpus_per_trial,
+        gpus_per_trial=gpus_per_trial,
     )
 
 
@@ -813,6 +829,8 @@ def train_nn_class(
     seed_model,
     tax,
     tree_phylo,
+    cpus_per_trial=1,
+    gpus_per_trial=0,
 ):
     train_nn(
         config,
@@ -824,6 +842,8 @@ def train_nn_class(
         seed_model,
         stratify_by,
         nn_type="classification",
+        cpus_per_trial=cpus_per_trial,
+        gpus_per_trial=gpus_per_trial,
     )
 
 
@@ -837,6 +857,8 @@ def train_nn_corn(
     seed_model,
     tax,
     tree_phylo,
+    cpus_per_trial=1,
+    gpus_per_trial=0,
 ):
     # corn model from https://github.com/Raschka-research-group/coral-pytorch
     train_nn(
@@ -849,6 +871,8 @@ def train_nn_corn(
         seed_model,
         stratify_by,
         nn_type="ordinal_regression",
+        cpus_per_trial=cpus_per_trial,
+        gpus_per_trial=gpus_per_trial,
     )
 
 
@@ -986,6 +1010,8 @@ def train_xgb(
     seed_model: int,
     tax: pd.DataFrame = pd.DataFrame(),
     tree_phylo: skbio.TreeNode = skbio.TreeNode(),
+    cpus_per_trial: int = 1,
+    gpus_per_trial: int = 0,
 ) -> None:
     """
     Train an XGBoost model and report the results to Ray Tune.
@@ -999,10 +1025,18 @@ def train_xgb(
     seed_model (int): The seed for the model.
     tax (pd.DataFrame): Taxonomy data.
     tree_phylo (skbio.TreeNode): Phylogenetic tree.
+    cpus_per_trial (int): Number of CPUs allocated by Ray Tune for this trial.
+    gpus_per_trial (int): Number of GPUs allocated by Ray Tune for this trial.
 
     Returns:
     None
     """
+    # Limit XGBoost threads to Ray-allocated CPUs to avoid oversubscription
+    config["nthread"] = cpus_per_trial
+    # Use GPU when allocated by Ray Tune
+    if gpus_per_trial > 0:
+        config["device"] = "cuda"
+
     # ! process dataset
     X_train, y_train, X_val, y_val = process_train(
         config, train_val, target, host_id, tax, seed_data, stratify_by=stratify_by

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -281,7 +281,7 @@ class TestTrainables(unittest.TestCase):
             max_features=config["max_features"],
             min_impurity_decrease=config["min_impurity_decrease"],
             bootstrap=config["bootstrap"],
-            n_jobs=None,
+            n_jobs=1,
             random_state=0,
         )
         mock_rf_instance.fit.assert_called_once()
@@ -345,7 +345,9 @@ class TestTrainables(unittest.TestCase):
             self.tax,
         )
 
-        # Assert
+        # Assert nthread is set to default cpus_per_trial and no GPU device
+        self.assertEqual(config["nthread"], 1)
+        self.assertNotIn("device", config)
         mock_process_train.assert_called_once_with(
             config,
             self.train_val,
@@ -363,6 +365,44 @@ class TestTrainables(unittest.TestCase):
         )
         mock_xgb_train.assert_called_once()
         mock_checkpoint.assert_called_once()
+
+    @patch("ritme.model_space.static_trainables._save_taxonomy")
+    @patch("ritme.model_space.static_trainables.process_train")
+    @patch("ritme.model_space.static_trainables.xgb.DMatrix")
+    @patch("ritme.model_space.static_trainables.xgb.train")
+    @patch("ritme.model_space.static_trainables._RitmeXGBCheckpointCallback")
+    def test_train_xgb_with_gpu(
+        self,
+        mock_checkpoint,
+        mock_xgb_train,
+        mock_dmatrix,
+        mock_process_train,
+        mock_save_taxonomy,
+    ):
+        config = {"n_estimators": 100}
+        mock_process_train.return_value = (
+            np.zeros((2, 2)),
+            np.zeros(2),
+            np.zeros((1, 2)),
+            np.zeros(1),
+        )
+        mock_dmatrix.return_value = None
+
+        st.train_xgb(
+            config,
+            self.train_val,
+            self.target,
+            self.host_id,
+            None,
+            self.seed_data,
+            self.seed_model,
+            self.tax,
+            cpus_per_trial=4,
+            gpus_per_trial=1,
+        )
+
+        self.assertEqual(config["nthread"], 4)
+        self.assertEqual(config["device"], "cuda")
 
     @parameterized.expand(
         [
@@ -448,7 +488,9 @@ class TestTrainables(unittest.TestCase):
             seed_data,
             stratify_by=None,
         )
-        mock_load_data.assert_called()
+        # Verify DataLoader workers scale with cpus_per_trial (default=1 → 0 workers)
+        load_data_call = mock_load_data.call_args
+        self.assertEqual(load_data_call.kwargs.get("num_workers"), 0)
         mock_neural_net.assert_called_once_with(
             n_units=nb_units,
             learning_rate=0.01,
@@ -542,6 +584,7 @@ class TestTrainableLogging(unittest.TestCase):
                     stratify_by=None,
                     tax=self.tax,
                     tree_phylo=self.tree_phylo,
+                    cpus_per_trial=1,
                 ),
                 param_space=search_space,
                 tune_config=tune.TuneConfig(metric=metric, mode=mode, num_samples=1),

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -236,12 +236,13 @@ def run_trials(
         # If not a SLURM process, default values are used
         resources = _get_resources(max_concurrent_trials)
 
-    # Fun facts about trainables and their parallelization/GPU capabilities:
-    # - linreg: not parallelizable + CPU-based
-    # - trac: solver Path-Alg not parallelized by default + Classo is a
-    #   CPU-based library
-    # - rf: parallel processing supported but no GPU support
-    # - xgb, nn_reg, nn_class, nn_corn: parallel processing supported with GPU support
+    # Trainable parallelization & GPU capabilities:
+    # - linreg: not parallelizable, CPU-only
+    # - trac: solver Path-Alg not parallelized, CPU-only (Classo)
+    # - rf: parallel via n_jobs, CPU-only
+    # - xgb: parallel via nthread, GPU via device='cuda' when allocated
+    # - nn_reg, nn_class, nn_corn: parallel via torch threads, GPU auto-detected
+    #   by Lightning via CUDA_VISIBLE_DEVICES set by Ray
 
     # Set seed for search algorithms/schedulers
     random.seed(seed_model)
@@ -291,6 +292,10 @@ def run_trials(
 
     callbacks = _define_callbacks(tracking_uri, exp_name, experiment_tag)
 
+    # Inject allocated resource counts so trainables can configure parallelism
+    cpus_per_trial = resources.get("cpu", 1)
+    gpus_per_trial = resources.get("gpu", 0)
+
     analysis = tune.Tuner(
         # Trainable with input parameters passed and set resources
         tune.with_resources(
@@ -304,6 +309,8 @@ def run_trials(
                 seed_model=seed_model,
                 tax=tax,
                 tree_phylo=tree_phylo,
+                cpus_per_trial=cpus_per_trial,
+                gpus_per_trial=gpus_per_trial,
             ),
             resources,
         ),


### PR DESCRIPTION
Closes #88

## Summary

- Fix CPU oversubscription: pass Ray Tune's allocated `cpus_per_trial` and `gpus_per_trial` into each trainable so they respect resource boundaries instead of using all system threads
- XGBoost: set `nthread` to allocated CPUs; set `device='cuda'` when GPUs are allocated
- Neural networks: limit PyTorch intra-op threads via `torch.set_num_threads`; scale DataLoader `num_workers` to `cpus_per_trial - 1` (reserve 1 CPU for training)
- Random Forest: set `n_jobs` to allocated CPUs (was `None` = all system CPUs)
- All other trainables (linreg, trac): accept resource parameters for interface consistency
- Pin `mlflow >=2.0` in conda recipe to fix protobuf incompatibility on install
- Simplify conda build channels to `-c conda-forge` only (drop bioconda, pytorch, defaults, anaconda)

## Problem

Previously, when Ray Tune allocated e.g. 2 CPUs per trial with 4 concurrent trials on an 8-CPU machine:
- XGBoost used all 8 system threads (no `nthread` set)
- PyTorch used all 8 system threads (no `torch.set_num_threads` call)
- Random Forest used all CPUs (`n_jobs=None`)
- XGBoost never used GPUs even when allocated

This caused 4x oversubscription (32 thread attempts on 8 CPUs), leading to context switching overhead and poor CPU utilization.

## Changes

### Resource-aware trainables (`ritme/model_space/static_trainables.py`)
| Trainable | CPU fix | GPU fix |
|-----------|---------|---------|
| `train_xgb` | `config["nthread"] = cpus_per_trial` | `config["device"] = "cuda"` when GPUs allocated |
| `train_nn` (all variants) | `torch.set_num_threads(cpus_per_trial)` + DataLoader `num_workers = max(0, cpus_per_trial - 1)` | Auto-detected by Lightning via `CUDA_VISIBLE_DEVICES` (set by Ray) |
| `train_rf` | `n_jobs=cpus_per_trial` | N/A (scikit-learn is CPU-only) |
| `train_linreg`, `train_trac` | Accept params (not parallelizable) | N/A |

### Resource injection (`ritme/tune_models.py`)
- Extract `cpus_per_trial` and `gpus_per_trial` from Ray's resource dict
- Pass both to trainables via `tune.with_parameters`
- Updated inline documentation of trainable capabilities

### Conda packaging (`ci/recipe/meta.yaml`, `.github/workflows/build_n_upload_package.yml`, `Makefile`)
- Pin `mlflow >=2.0` to prevent protobuf descriptor incompatibility (conda was pulling mlflow 1.2.0 from the anaconda channel)
- Remove `conda-forge::` prefixes from dependencies (redundant when building with `-c conda-forge`)
- Simplify build channels to `-c conda-forge` only

### Tests (`ritme/tests/test_model_static_trainables.py`)
- Updated RF test: assert `n_jobs=1` (was `n_jobs=None`)
- Updated XGB test: assert `nthread` is set, `device` is absent without GPU
- Added `test_train_xgb_with_gpu`: verify `device='cuda'` when `gpus_per_trial=1`
- Updated NN test: assert DataLoader `num_workers` scales with `cpus_per_trial`
- Updated integration test: pass `cpus_per_trial` to `tune.with_parameters`
