### PR TITLE
FIX: XGB checkpoint with min. ray version

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - py-xgboost
     - python-dotenv
     - pytorch
-    - conda-forge::ray-default
-    - conda-forge::ray-tune
+    - conda-forge::ray-default >=2.54
+    - conda-forge::ray-tune >=2.54
     - scikit-bio
     - scikit-learn
     - scipy


### PR DESCRIPTION
This PR fixes the XGB checkpoint callback to rely on newer versions of Ray.

The custom `_RitmeXGBCheckpointCallback` relies on private methods (`_save_and_report_checkpoint`, `_report_metrics`) from Ray's `TuneReportCheckpointCallback`, which were only introduced in Ray 2.54. The dependency was previously unpinned, allowing older versions to be installed.