### PR TITLE
FIX: Restore user-defined `experiment_tag` 

### DIFF
--- a/ritme/find_best_model_config.py
+++ b/ritme/find_best_model_config.py
@@ -239,6 +239,7 @@ def find_best_model_config(
             # time_budget for search
             config["time_budget_s"],
             config["max_cuncurrent_trials"],
+            config["experiment_tag"],
             model_types=config["ls_model_types"],
             fully_reproducible=config["fully_reproducible"],
             model_hyperparameters=config.get("model_hyperparameters", {}),

--- a/ritme/tests/test_classification.py
+++ b/ritme/tests/test_classification.py
@@ -344,6 +344,7 @@ class TestRunAllTrialsTaskTypeValidation(unittest.TestCase):
                 path_exp="/tmp/exp",
                 time_budget_s=10,
                 max_concurrent_trials=1,
+                experiment_tag="test_experiment",
                 model_types=["xgb"],
                 task_type="invalid",
             )
@@ -366,6 +367,7 @@ class TestRunAllTrialsTaskTypeValidation(unittest.TestCase):
                 path_exp="/tmp/exp",
                 time_budget_s=10,
                 max_concurrent_trials=1,
+                experiment_tag="test_experiment",
                 model_types=["xgb"],
                 task_type="classification",
             )
@@ -391,6 +393,7 @@ class TestRunAllTrialsTaskTypeValidation(unittest.TestCase):
             path_exp="/tmp/exp",
             time_budget_s=10,
             max_concurrent_trials=1,
+            experiment_tag="test_experiment",
             model_types=["nn_class", "nn_corn"],
             task_type="regression",
         )

--- a/ritme/tests/test_find_best_model_config.py
+++ b/ritme/tests/test_find_best_model_config.py
@@ -255,6 +255,7 @@ class TestFindBestModelConfig(unittest.TestCase):
                 ANY,  # tmp_storage (temp dir)
                 self.config["time_budget_s"],
                 self.config["max_cuncurrent_trials"],
+                self.config["experiment_tag"],
                 model_types=self.config["ls_model_types"],
                 fully_reproducible=False,
                 model_hyperparameters={},

--- a/ritme/tests/test_tune_models.py
+++ b/ritme/tests/test_tune_models.py
@@ -231,10 +231,58 @@ class TestMainTuneModels(unittest.TestCase):
         self.tax = pd.DataFrame()
         self.tree_phylo = skbio.TreeNode()
         self.path2exp = "/tmp/experiment"
+        self.experiment_tag = "test_experiment_tag"
         self.time_budget_s = 5
         self.max_concurrent_trials = 2
         self.model_hyperparameters = {}
         self.mlflow_uri = "sqlite:///tmp/experiment/mlflow.db"
+
+    @patch("ritme.tune_models.init")
+    @patch("ritme.tune_models.ray.cluster_resources")
+    @patch("ritme.tune_models.tune.Tuner")
+    def test_run_trials_uses_passed_experiment_tag_for_callback(
+        self, mock_tuner_class, mock_resources, mock_init
+    ):
+        # Regression test: experiment_tag must come from the caller, not from
+        # os.path.basename(path2exp). path2exp here is a throwaway temp dir,
+        # but the MLflow tag should still be the user-supplied experiment_tag.
+        mock_context = MagicMock()
+        mock_context.dashboard_url = "http://localhost:8265"
+        mock_init.return_value = mock_context
+        mock_resources.return_value = {}
+        mock_tuner = MagicMock()
+        mock_tuner.fit.return_value = MagicMock(spec=ResultGrid, num_errors=0)
+        mock_tuner_class.return_value = mock_tuner
+
+        temp_path2exp = "/tmp/tmp_throwaway_abc123"
+        user_tag = "my_real_experiment"
+
+        run_trials(
+            tracking_uri=self.mlflow_uri,
+            exp_name="test_experiment",
+            trainable=MagicMock(),
+            train_val=self.train_val,
+            target=self.target,
+            host_id=self.host_id,
+            stratify_by=None,
+            seed_data=self.seed_data,
+            seed_model=self.seed_model,
+            tax=self.tax,
+            tree_phylo=self.tree_phylo,
+            path2exp=temp_path2exp,
+            time_budget_s=self.time_budget_s,
+            max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=user_tag,
+            fully_reproducible=False,
+            model_hyperparameters=self.model_hyperparameters,
+        )
+
+        run_config = mock_tuner_class.call_args.kwargs["run_config"]
+        mlflow_cb = run_config.callbacks[0]
+        self.assertEqual(mlflow_cb.tags, {"experiment_tag": user_tag})
+        self.assertNotEqual(
+            mlflow_cb.tags["experiment_tag"], os.path.basename(temp_path2exp)
+        )
 
     @patch("ritme.tune_models.init")
     @patch("ritme.tune_models.ray.cluster_resources")
@@ -269,6 +317,7 @@ class TestMainTuneModels(unittest.TestCase):
             path2exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             fully_reproducible=False,
             model_hyperparameters=self.model_hyperparameters,
         )
@@ -298,6 +347,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
         )
@@ -330,6 +380,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
         )
@@ -354,6 +405,7 @@ class TestMainTuneModels(unittest.TestCase):
             self.path2exp,
             self.time_budget_s,
             self.max_concurrent_trials,
+            self.experiment_tag,
             fully_reproducible=False,
             model_hyperparameters={"data_enrich_with": None},
             optuna_searchspace_sampler="TPESampler",
@@ -390,6 +442,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
         )
@@ -426,6 +479,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
         )
@@ -464,6 +518,7 @@ class TestMainTuneModels(unittest.TestCase):
             path2exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             fully_reproducible=False,
             model_hyperparameters=self.model_hyperparameters,
             task_type="classification",
@@ -503,6 +558,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
             task_type="classification",
@@ -549,6 +605,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=self.model_hyperparameters,
             task_type="classification",
@@ -581,6 +638,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=model_hyperparameters,
             task_type="classification",
@@ -618,6 +676,7 @@ class TestMainTuneModels(unittest.TestCase):
             path_exp=self.path2exp,
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
+            experiment_tag=self.experiment_tag,
             model_types=model_types,
             model_hyperparameters=model_hyperparameters,
             task_type="classification",

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -233,6 +233,7 @@ def run_trials(
     path2exp: str,
     time_budget_s: int,
     max_concurrent_trials: int,
+    experiment_tag: str,
     fully_reproducible: bool = False,
     model_hyperparameters: dict = None,
     optuna_searchspace_sampler: str = "TPESampler",
@@ -299,7 +300,6 @@ def run_trials(
     )
 
     storage_path = os.path.abspath(path2exp)
-    experiment_tag = os.path.basename(path2exp)
 
     callbacks = _define_callbacks(tracking_uri, exp_name, experiment_tag)
 
@@ -383,6 +383,7 @@ def run_all_trials(
     path_exp: str,
     time_budget_s: int,
     max_concurrent_trials: int,
+    experiment_tag: str,
     model_types: list = [
         "xgb",
         "nn_reg",
@@ -504,6 +505,7 @@ def run_all_trials(
             path_exp,
             time_budget_s,
             max_concurrent_trials_launched,
+            experiment_tag,
             fully_reproducible=fully_reproducible,
             model_hyperparameters=model_hparams_type,
             optuna_searchspace_sampler=optuna_searchspace_sampler,


### PR DESCRIPTION
Trial logs (MLflow tag `experiment_tag`, WandB project/tag) had been silently carrying the temporary-directory basename instead of the user's `config["experiment_tag"]`, breaking the link from each trial back to its experiment folder.

Solution:
- Thread `experiment_tag` explicitly from the config through `run_all_trials` → `run_trials` → `_define_callbacks` instead of deriving it from `os.path.basename(path2exp)`.
- Add a regression test asserting the MLflow callback tag matches the caller-supplied `experiment_tag`, even when `path2exp` is a throwaway temp dir.

## Why
`README.md` states that `experiment_tag` names the experiment and determines its output folder (`<path-store-model-logs>/experiment_tag`). Since `1d78640` (#95, "ENH: Inode-efficient storage for experiment logs"), trials are run from a `tempfile.TemporaryDirectory()` to reduce inode usage. But `run_trials` still computed `experiment_tag = os.path.basename(path2exp)`, so the tag became the random temp-dir name (e.g. `tmpa1b2c3d4`). This broke the link between trial logs and the experiment folder described in the README, and made the WandB project name a throwaway per run.

## Changes
- `ritme/tune_models.py`:
  - Add required `experiment_tag: str` parameter to `run_trials` and
    `run_all_trials`; stop deriving it from `path2exp`.
- `ritme/find_best_model_config.py`:
  - Pass `config["experiment_tag"]` to `run_all_trials`.
- `ritme/tests/test_tune_models.py`:
  - Thread `experiment_tag` through all existing `run_trials` /
    `run_all_trials` test calls.
  - Add `test_run_trials_uses_passed_experiment_tag_for_callback` regression
    test confirming the MLflow callback tag equals the user-supplied tag and
    not `basename(path2exp)`.
- `ritme/tests/test_find_best_model_config.py`:
  - Extend the `run_all_trials` call-signature assertion to include
    `config["experiment_tag"]`.
- `ritme/tests/test_classification.py`:
  - Pass `experiment_tag` to the three `run_all_trials` calls.
