### PR TITLE
ENH: Consistent splits and NaN-mode improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ When testing new functionality always do it in an activated conda environment ca
 - **Compositionality per snapshot**: Microbial features within a single time point are compositional. Transforms (CLR/ILR/ALR) are applied per snapshot, never across time points.
 - **No data leakage**: Feature engineering parameters (selection, ALR denominator, enrichment schema) are learned on train and reused as-is on test via `TunedModel` state.
 - **TRAC incompatibility**: TRAC requires a single compositional snapshot + phylogenetic tree. It is automatically excluded when dynamic snapshots are detected.
-- **NaN handling**: `missing_mode="nan"` restricts the model search to XGBoost (native NaN support). NaN rows are separated before compositional transforms and reintroduced afterward.
+- **NaN handling**: `missing_mode="nan"` requires `ls_model_types` to contain only XGBoost; requesting any other model raises a `ValueError`. NaN rows are separated before compositional transforms and reintroduced afterward.
 - **Column naming**: Past snapshots are suffixed (`F0__t-1`, `age__t-2`); current (t0) columns remain unsuffixed. This ensures backward compatibility with the static workflow.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To prevent data leakage, set `group_by_column` (e.g. `"host_id"`) so that all sa
 
 - **Identical feature columns across snapshots** — all time points for a host must share the same set of microbial feature columns.
 - **TRAC is incompatible with dynamic snapshotting** — TRAC requires a single compositional snapshot and phylogenetic tree; it is automatically removed from the model search when past snapshots are detected.
-- **`missing_mode="nan"` restricts to XGBoost** — only XGBoost handles NaN values natively, so when NaN-filled snapshots are present, the model search is automatically restricted to XGBoost.
+- **`missing_mode="nan"` requires XGBoost** — only XGBoost handles NaN values natively. When NaN-filled snapshots are present and `ls_model_types` contains any non-XGBoost model, `find_best_model_config` raises an error. Either set `missing_mode="exclude"` or restrict `ls_model_types` to `["xgb"]` (regression) / `["xgb_class"]` (classification).
 - **`time_col` must be numeric** — values are interpreted as ordered integers or floats; non-numeric values raise an error.
 
 ## Finding the best model configuration with `find_best_model_config`

--- a/ritme/split_train_test.py
+++ b/ritme/split_train_test.py
@@ -48,7 +48,9 @@ def _ft_remove_zero_features(ft: pd.DataFrame) -> pd.DataFrame:
     ft_removed = ft.copy()
     drop_fts = ft_removed.loc[:, ft_removed.sum(axis=0) == 0.0].columns.tolist()
     if len(drop_fts) > 0:
-        warnings.warn(f"Dropping these features with all zero values: {drop_fts}")
+        warnings.warn(
+            f"Dropping {len(drop_fts)} features with all zero values: {drop_fts}"
+        )
         ft_removed.drop(columns=drop_fts, inplace=True)
     else:
         ft_removed = ft.copy()
@@ -529,7 +531,8 @@ def split_train_test(
         md_base, ft_merged = _merge_time_snapshots(md_list, ft_list)
     else:
         md_base = md.copy()
-        ft_merged = _prepare_single_feature_table(ft)
+        common_idx = md.index.intersection(ft.index)
+        ft_merged = _prepare_single_feature_table(ft.loc[common_idx])
 
     # merge md and feature table (inner join on sample ids)
     data = md_base.join(ft_merged, how="inner")

--- a/ritme/tests/test_split_train_test.py
+++ b/ritme/tests/test_split_train_test.py
@@ -43,7 +43,7 @@ class TestFeatureTableHelpers(unittest.TestCase):
         self.assertListEqual(renamed.columns.tolist(), expected_columns)
 
     def test_ft_remove_zero_features(self):
-        with self.assertWarnsRegex(Warning, r".*all zero values: \['F2'\]"):
+        with self.assertWarnsRegex(Warning, r".*all zero values.*\['F2'\]"):
             removed = _ft_remove_zero_features(self.ft_renamed)
             pd.testing.assert_frame_equal(removed, self.ft_zero_remov)
 
@@ -380,6 +380,21 @@ class TestMainFunctions(unittest.TestCase):
                 seed=123,
                 stratify_by=["covariate"],
             )
+
+    def test_split_train_test_static_drops_ghost_zero_features(self):
+        """Features non-zero only in ft-only samples must not survive."""
+        md = pd.DataFrame(
+            {"host_id": ["a", "b"], "target": [1, 2]},
+            index=["s1", "s2"],
+        )
+        ft = pd.DataFrame(
+            {"0": [0.5, 0.5, 0.0], "1": [0.5, 0.5, 0.0], "2": [0.0, 0.0, 1.0]},
+            index=["s1", "s2", "s3"],
+        )
+        train, test = split_train_test(md, ft, train_size=0.0, seed=0)
+        self.assertNotIn("F2", test.columns)
+        self.assertIn("F0", test.columns)
+        self.assertIn("F1", test.columns)
 
 
 class TestSplitTrainTestTemporalSnapshots(unittest.TestCase):

--- a/ritme/tests/test_tune_models.py
+++ b/ritme/tests/test_tune_models.py
@@ -450,7 +450,7 @@ class TestMainTuneModels(unittest.TestCase):
         self.assertNotIn("trac", results)
 
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_restrict_xgb(self, mock_run_trials):
+    def test_run_all_trials_nan_snapshots_rejects_non_xgb(self, mock_run_trials):
         # dataframe with NaN in snapshot features
         self.train_val = pd.DataFrame(
             {
@@ -466,6 +466,42 @@ class TestMainTuneModels(unittest.TestCase):
         mock_result = MagicMock(spec=ResultGrid)
         mock_run_trials.return_value = mock_result
         model_types = ["xgb", "rf", "trac"]
+        with self.assertRaisesRegex(ValueError, r"NaNs in snapshot features"):
+            run_all_trials(
+                train_val=self.train_val,
+                target=self.target,
+                host_id=self.host_id,
+                stratify_by=None,
+                seed_data=self.seed_data,
+                seed_model=self.seed_model,
+                tax=self.tax,
+                tree_phylo=self.tree_phylo,
+                mlflow_uri=self.mlflow_uri,
+                path_exp=self.path2exp,
+                time_budget_s=self.time_budget_s,
+                max_concurrent_trials=self.max_concurrent_trials,
+                experiment_tag=self.experiment_tag,
+                model_types=model_types,
+                model_hyperparameters=self.model_hyperparameters,
+            )
+        mock_run_trials.assert_not_called()
+
+    @patch("ritme.tune_models.run_trials")
+    def test_run_all_trials_nan_snapshots_xgb_only_ok(self, mock_run_trials):
+        # dataframe with NaN in snapshot features; only xgb requested
+        self.train_val = pd.DataFrame(
+            {
+                "F1": [0.1, 0.2],
+                "F2": [0.3, 0.4],
+                "F1__t-1": [np.nan, 0.15],
+                "F2__t-1": [0.25, np.nan],
+                "meta": [1, 2],
+                self.target: [0.5, 0.6],
+                self.host_id: ["a", "b"],
+            }
+        )
+        mock_result = MagicMock(spec=ResultGrid)
+        mock_run_trials.return_value = mock_result
         results = run_all_trials(
             train_val=self.train_val,
             target=self.target,
@@ -480,7 +516,7 @@ class TestMainTuneModels(unittest.TestCase):
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
             experiment_tag=self.experiment_tag,
-            model_types=model_types,
+            model_types=["xgb"],
             model_hyperparameters=self.model_hyperparameters,
         )
         self.assertEqual(list(results.keys()), ["xgb"])
@@ -576,8 +612,44 @@ class TestMainTuneModels(unittest.TestCase):
             self.assertEqual(call.kwargs.get("task_type"), "classification")
 
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_restrict_xgb_class(self, mock_run_trials):
+    def test_run_all_trials_nan_snapshots_rejects_non_xgb_class(self, mock_run_trials):
         # dataframe with NaN in snapshot features
+        self.train_val = pd.DataFrame(
+            {
+                "F1": [0.1, 0.2],
+                "F2": [0.3, 0.4],
+                "F1__t-1": [np.nan, 0.15],
+                "F2__t-1": [0.25, np.nan],
+                "meta": [1, 2],
+                self.target: [0.5, 0.6],
+                self.host_id: ["a", "b"],
+            }
+        )
+        model_types = ["xgb_class", "rf_class", "logreg"]
+        with self.assertRaisesRegex(ValueError, r"NaNs in snapshot features"):
+            run_all_trials(
+                train_val=self.train_val,
+                target=self.target,
+                host_id=self.host_id,
+                stratify_by=None,
+                seed_data=self.seed_data,
+                seed_model=self.seed_model,
+                tax=self.tax,
+                tree_phylo=self.tree_phylo,
+                mlflow_uri=self.mlflow_uri,
+                path_exp=self.path2exp,
+                time_budget_s=self.time_budget_s,
+                max_concurrent_trials=self.max_concurrent_trials,
+                experiment_tag=self.experiment_tag,
+                model_types=model_types,
+                model_hyperparameters=self.model_hyperparameters,
+                task_type="classification",
+            )
+        mock_run_trials.assert_not_called()
+
+    @patch("ritme.tune_models.run_trials")
+    def test_run_all_trials_nan_snapshots_xgb_class_only_ok(self, mock_run_trials):
+        # dataframe with NaN in snapshot features; only xgb_class requested
         self.train_val = pd.DataFrame(
             {
                 "F1": [0.1, 0.2],
@@ -591,7 +663,6 @@ class TestMainTuneModels(unittest.TestCase):
         )
         mock_result = MagicMock(spec=ResultGrid)
         mock_run_trials.return_value = mock_result
-        model_types = ["xgb_class", "rf_class", "logreg"]
         results = run_all_trials(
             train_val=self.train_val,
             target=self.target,
@@ -606,11 +677,10 @@ class TestMainTuneModels(unittest.TestCase):
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
             experiment_tag=self.experiment_tag,
-            model_types=model_types,
+            model_types=["xgb_class"],
             model_hyperparameters=self.model_hyperparameters,
             task_type="classification",
         )
-        # Only xgb_class should remain when NaN snapshots detected
         self.assertEqual(list(results.keys()), ["xgb_class"])
 
     @patch("ritme.tune_models.run_trials")

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -430,17 +430,17 @@ def run_all_trials(
         else False
     )
     if has_snapshots and has_snapshot_nans:
-        # Restrict to xgb/xgb_class only when NaNs in snapshot feature tables
+        # Only xgb/xgb_class support native NaN handling; reject any other request
         xgb_model = "xgb_class" if task_type == "classification" else "xgb"
-        if xgb_model not in model_types:
-            print(f"NaNs in snapshot features detected. Using only '{xgb_model}'.")
-        else:
-            if len(model_types) != 1:
-                print(
-                    f"NaNs in snapshot features detected. Restricting to "
-                    f"'{xgb_model}'."
-                )
-        model_types = [xgb_model]
+        incompatible = sorted(set(model_types) - {xgb_model})
+        if incompatible:
+            raise ValueError(
+                f"NaNs in snapshot features detected (missing_mode='nan'); only "
+                f"'{xgb_model}' supports native NaN handling. Requested model "
+                f"types {incompatible} are incompatible. Either set "
+                f"missing_mode='exclude' in split_train_test or restrict "
+                f"ls_model_types to ['{xgb_model}']."
+            )
     elif has_snapshots and "trac" in model_types:
         # Remove trac when dynamic snapshots present
         model_types.remove("trac")


### PR DESCRIPTION
### Changes
- **Static path zero-feature removal**: `split_train_test` now subsets `ft` to `md ∩ ft` indices before calling `_prepare_single_feature_table`, matching the dynamic path. Previously, features non-zero only in samples absent from metadata survived as ghost all-zero columns.
- **Reject incompatible models with `missing_mode="nan"`**: `run_all_trials` now raises a `ValueError` when NaN snapshot features are detected and non-XGBoost models are requested, instead of silently substituting XGBoost.

### Files changed
- `ritme/split_train_test.py` — subset `ft` to common indices before feature prep in static path; improved zero-feature warning message
- `ritme/tune_models.py` — replace silent model restriction with explicit error
- `ritme/tests/test_split_train_test.py` — added test for ghost zero-feature removal; updated warning regex
- `ritme/tests/test_tune_models.py` — converted silent-restriction tests to assert `ValueError`; added happy-path tests for xgb/xgb_class with NaN snapshots
- `README.md`, `AGENTS.md` — updated docs to reflect new behavior