### PR TITLE
FIX: conda package upload

### DIFF
--- a/.github/workflows/build_n_upload_package.yml
+++ b/.github/workflows/build_n_upload_package.yml
@@ -49,5 +49,8 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
           ANACONDA_USER: adamova
         run: |
-          # Upload the built package using the captured path
-          anaconda upload --force "${{ steps.build.outputs.package_path }}" --user $ANACONDA_USER
+          # Upload the built package using the captured path.
+          # `anaconda` lives in base/bin, but setup-miniconda@v3 activates the
+          # default `test` env, so the script isn't on PATH — invoke via
+          # `conda run -n base` so it resolves regardless of activation.
+          conda run -n base anaconda upload --force "${{ steps.build.outputs.package_path }}" --user $ANACONDA_USER


### PR DESCRIPTION
`setup-miniconda@v3` activates the default `test` env, so `anaconda` (installed in `base`) isn't on `PATH` and the upload step exited 127 with `anaconda: command not found`. Wrapped the upload in `conda run -n base` so it resolves regardless of activation.
