### PR TITLE
FIX: K-fold `get_best_result` no-checkpoint crash

### DIFF
--- a/ritme/evaluate_models.py
+++ b/ritme/evaluate_models.py
@@ -547,8 +547,10 @@ def _select_best_with_one_se(
 
     if not candidates:
         # No reliable K-fold trials -> defer to Ray Tune's single-best lookup,
-        # preserving the pre-K-fold behavior.
-        return result_grid.get_best_result(scope="all")
+        # preserving the pre-K-fold behavior. ``metric`` / ``mode`` are passed
+        # explicitly because ``TuneConfig`` no longer carries them (the
+        # scheduler owns them; Ray Tune disallows both -- see tune_models.py).
+        return result_grid.get_best_result(metric=metric, mode=mode, scope="all")
 
     # Best by sign-adjusted mean (lower-is-better -> sign=+1, etc.).
     best_result, best_mean, best_se = min(candidates, key=lambda x: sign * x[1])

--- a/ritme/model_space/static_trainables.py
+++ b/ritme/model_space/static_trainables.py
@@ -137,11 +137,26 @@ def _emit_running_fold_aggregate(
     only for ``fold_idx`` in ``0..n_splits - 2`` -- the last fold's metrics
     are surfaced by the post-refit final report, which also carries the
     deployable checkpoint. No checkpoint is attached here.
+
+    Bare metric keys (``<metric>``) are stripped from the running report; only
+    the suffixed variants (``<metric>_mean`` / ``_std`` / ``_se``) plus
+    ``n_folds`` / ``nb_features`` survive. This isolates the bare keys to the
+    final post-refit report, so Ray Tune's ``get_best_result(metric=<metric>)``
+    can only land on a row that carries the deployable checkpoint -- see
+    ``issue_eval_class.md`` for the no-checkpoint crash this fix prevents.
+    The K-fold scheduler is configured to monitor ``<metric>_mean`` instead
+    of ``<metric>`` so ASHA pruning still fires at fold boundaries.
     """
     if fold_idx >= n_splits - 1:
         return
     running = _aggregate_fold_metrics(per_fold_metrics)
     running["nb_features"] = nb_features
+    # Strip bare metric keys; keep only suffixed variants + bookkeeping.
+    _KEEP_BARE = {"n_folds", "nb_features"}
+    _SUFFIXES = ("_mean", "_std", "_se")
+    running = {
+        k: v for k, v in running.items() if k in _KEEP_BARE or k.endswith(_SUFFIXES)
+    }
     tune.report(metrics=running)
 
 

--- a/ritme/tests/test_evaluate_models.py
+++ b/ritme/tests/test_evaluate_models.py
@@ -659,7 +659,9 @@ class TestOneStandardErrorRule(unittest.TestCase):
             ]
         )
         chosen = _select_best_with_one_se(rg, "rmse_val", "min", "linreg")
-        rg.get_best_result.assert_called_once_with(scope="all")
+        rg.get_best_result.assert_called_once_with(
+            metric="rmse_val", mode="min", scope="all"
+        )
         self.assertIs(chosen, sentinel)
 
     def test_picks_simplest_within_band_for_min_metric(self):
@@ -842,7 +844,9 @@ class TestOneStandardErrorRule(unittest.TestCase):
         rg.get_best_result.return_value = sentinel
         rg.__iter__ = lambda self: iter([a, b])
         chosen = _select_best_with_one_se(rg, "rmse_val", "min", "linreg")
-        rg.get_best_result.assert_called_once_with(scope="all")
+        rg.get_best_result.assert_called_once_with(
+            metric="rmse_val", mode="min", scope="all"
+        )
         self.assertIs(chosen, sentinel)
 
     def test_simplicity_knobs_match_actual_search_space(self):

--- a/ritme/tests/test_model_static_trainables.py
+++ b/ritme/tests/test_model_static_trainables.py
@@ -1242,6 +1242,13 @@ class TestKfoldHelpers(unittest.TestCase):
         # in the payload must equal the count of completed folds (not the
         # total ``n_splits``), and no ``checkpoint`` kwarg is attached --
         # the deployable artifact only exists after the post-loop refit.
+        #
+        # Bare metric keys (``rmse_val``) are STRIPPED from running
+        # aggregates; only the suffixed variants (``_mean`` / ``_std`` /
+        # ``_se``) plus bookkeeping (``n_folds`` / ``nb_features``) survive.
+        # This isolates the bare keys to the final post-refit report so
+        # Ray Tune's ``get_best_result(metric=<metric>)`` cannot land on a
+        # checkpoint-less row (see ``issue_eval_class.md``).
         st._emit_running_fold_aggregate(
             per_fold_metrics=[{"rmse_val": 0.4}],
             nb_features=10,
@@ -1259,7 +1266,10 @@ class TestKfoldHelpers(unittest.TestCase):
             metrics = actual_call.kwargs["metrics"]
             self.assertEqual(metrics["n_folds"], expected_n_folds)
             self.assertEqual(metrics["nb_features"], 10)
-            self.assertIn("rmse_val", metrics)
+            self.assertNotIn("rmse_val", metrics)
+            self.assertIn("rmse_val_mean", metrics)
+            self.assertIn("rmse_val_std", metrics)
+            self.assertIn("rmse_val_se", metrics)
             self.assertNotIn("checkpoint", actual_call.kwargs)
 
 
@@ -1651,13 +1661,16 @@ class TestKfoldTrainables(unittest.TestCase):
 
             # Mid-trial reports carry a running aggregate (n_folds grows
             # 1, 2) and no checkpoint -- the deployable artifact only
-            # exists after the post-loop refit.
+            # exists after the post-loop refit. Bare metric keys are
+            # stripped from running aggregates (see issue_eval_class.md);
+            # only the suffixed variants survive.
             for fold_idx, expected_n_folds in enumerate((1, 2), start=0):
                 metrics = calls[fold_idx].kwargs.get("metrics")
                 if metrics is None:
                     metrics = calls[fold_idx].args[0]
                 self.assertEqual(metrics["n_folds"], expected_n_folds)
-                self.assertIn("rmse_val", metrics)
+                self.assertNotIn("rmse_val", metrics)
+                self.assertIn("rmse_val_mean", metrics)
                 self.assertNotIn(
                     "checkpoint",
                     calls[fold_idx].kwargs,

--- a/ritme/tests/test_tune_models.py
+++ b/ritme/tests/test_tune_models.py
@@ -81,7 +81,7 @@ class TestHelpersTuneModels(unittest.TestCase):
     def test_define_scheduler_not_fully_reproducible(self):
         scheduler_max_t = 100
 
-        scheduler = _define_scheduler(False, 10, scheduler_max_t)
+        scheduler = _define_scheduler(False, 10, scheduler_max_t, "rmse_val", "min", 1)
 
         self.assertIsInstance(scheduler, AsyncHyperBandScheduler)
         self.assertEqual(scheduler._max_t, scheduler_max_t)
@@ -89,10 +89,24 @@ class TestHelpersTuneModels(unittest.TestCase):
     def test_define_scheduler_fully_reproducible(self):
         scheduler_max_t = 100
 
-        scheduler = _define_scheduler(True, 10, scheduler_max_t)
+        scheduler = _define_scheduler(True, 10, scheduler_max_t, "rmse_val", "min", 1)
 
         self.assertIsInstance(scheduler, HyperBandScheduler)
         self.assertEqual(scheduler._max_t_attr, scheduler_max_t)
+
+    def test_define_scheduler_uses_mean_suffix_when_kfold(self):
+        # K-fold (k_folds > 1) must point the scheduler at ``<metric>_mean``
+        # since the running aggregate strips the bare ``<metric>`` key (see
+        # issue_eval_class.md).
+        scheduler = _define_scheduler(False, 10, 100, "rmse_val", "min", 5)
+        self.assertEqual(scheduler._metric, "rmse_val_mean")
+        self.assertEqual(scheduler._mode, "min")
+
+    def test_define_scheduler_uses_bare_metric_when_single_split(self):
+        # k_folds == 1 keeps the bare ``<metric>`` because the single-split
+        # callbacks emit it every epoch.
+        scheduler = _define_scheduler(False, 10, 100, "rmse_val", "min", 1)
+        self.assertEqual(scheduler._metric, "rmse_val")
 
     @parameterized.expand(
         [
@@ -603,11 +617,19 @@ class TestMainTuneModels(unittest.TestCase):
             task_type="classification",
         )
 
-        # Verify Tuner was configured with classification metric/mode
+        # Verify the scheduler -- which now owns metric/mode (Tuner-level
+        # metric/mode is intentionally None to avoid Ray Tune's "metric set
+        # in both scheduler and Tuner" guard, see issue_eval_class.md) --
+        # was configured with the classification metric.
         tuner_call_kwargs = mock_tuner_class.call_args
         tune_config = tuner_call_kwargs.kwargs["tune_config"]
-        self.assertEqual(tune_config.metric, "roc_auc_macro_ovr_val")
-        self.assertEqual(tune_config.mode, "max")
+        self.assertIsNone(tune_config.metric)
+        self.assertIsNone(tune_config.mode)
+        # K-fold mode reads ``<metric>_mean``; single-split reads ``<metric>``.
+        # ``k_folds`` defaults to 1 in ``run_trials`` so this assertion
+        # tracks the single-split branch.
+        self.assertEqual(tune_config.scheduler._metric, "roc_auc_macro_ovr_val")
+        self.assertEqual(tune_config.scheduler._mode, "max")
 
         # Verify checkpoint config also uses classification metric
         run_config = tuner_call_kwargs.kwargs["run_config"]

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -216,8 +216,23 @@ def _get_resources(max_concurrent_trials: int) -> dict:
 
 
 def _define_scheduler(
-    fully_reproducible: bool, scheduler_grace_period: int, scheduler_max_t: int
+    fully_reproducible: bool,
+    scheduler_grace_period: int,
+    scheduler_max_t: int,
+    metric: str,
+    mode: str,
+    k_folds: int,
 ):
+    # In K-fold mode the running aggregate reports strip the bare ``<metric>``
+    # key (see ``_emit_running_fold_aggregate`` / ``issue_eval_class.md``) so
+    # that Ray Tune's ``get_best_result(metric=<metric>)`` cannot land on a
+    # checkpoint-less row. The scheduler must therefore monitor a key that
+    # survives in the running aggregates -- ``<metric>_mean`` -- otherwise it
+    # would see no metric mid-trial and never prune. In single-split mode the
+    # callbacks emit ``<metric>`` per epoch, so the scheduler reads it
+    # directly.
+    sched_metric = f"{metric}_mean" if int(k_folds or 1) > 1 else metric
+
     # Note: Both schedulers might decide to run more trials than allocated
     if not fully_reproducible:
         # AsyncHyperBand enables aggressive early stopping of bad trials.
@@ -225,6 +240,8 @@ def _define_scheduler(
         # ! not fully reproducible with seeds (caused by system load, network
         # ! communication and other factors in env) due to asynchronous mode only
         return AsyncHyperBandScheduler(
+            metric=sched_metric,
+            mode=mode,
             # Stop trials at least this old in time (measured in training iteration)
             grace_period=scheduler_grace_period,
             # Stopping trials after max_t iterations have passed
@@ -234,7 +251,7 @@ def _define_scheduler(
         # ! HyperBandScheduler slower BUT
         # ! improves the reproducibility of experiments by ensuring that all trials
         # ! are evaluated in the same order.
-        return HyperBandScheduler(max_t=scheduler_max_t)
+        return HyperBandScheduler(metric=sched_metric, mode=mode, max_t=scheduler_max_t)
 
 
 def _define_search_algo(
@@ -431,9 +448,23 @@ def run_trials(
     # Define metric and mode to optimize
     metric, mode = TASK_METRICS[task_type]
 
+    # In K-fold mode the running aggregate reports strip the bare ``<metric>``
+    # key (see ``_emit_running_fold_aggregate`` / ``issue_eval_class.md``) so
+    # that ``get_best_result(metric=<metric>)`` cannot land on a checkpoint-
+    # less row. Both the scheduler and the search algorithm must therefore
+    # monitor a key that appears in EVERY report (running + final);
+    # ``<metric>_mean`` fits. Ray Tune's strict metric validator also enforces
+    # the search algo's metric to be present on every report.
+    runtime_metric = f"{metric}_mean" if int(k_folds or 1) > 1 else metric
+
     # Define schedulers
     scheduler = _define_scheduler(
-        fully_reproducible, scheduler_grace_period, scheduler_max_t
+        fully_reproducible,
+        scheduler_grace_period,
+        scheduler_max_t,
+        metric,
+        mode,
+        k_folds,
     )
 
     # Define search algorithm with search space
@@ -445,7 +476,7 @@ def run_trials(
         model_hyperparameters,
         optuna_searchspace_sampler,
         seed_model,
-        metric,
+        runtime_metric,
         mode,
     )
 
@@ -500,9 +531,13 @@ def run_trials(
             callbacks=callbacks,
         ),
         tune_config=tune.TuneConfig(
-            metric=metric,
-            mode=mode,
-            # Define the scheduler
+            # ``metric`` / ``mode`` are intentionally NOT set here: the
+            # scheduler holds them (so K-fold can read ``<metric>_mean``
+            # while single-split reads ``<metric>``), and Ray Tune raises
+            # if both Tuner and scheduler specify them. ``search_alg`` and
+            # ``scheduler`` already carry the values they need; downstream
+            # ``get_best_result`` calls must pass ``metric`` / ``mode``
+            # explicitly (see ``_select_best_with_one_se``).
             scheduler=scheduler,
             # Number of trials to run - schedulers might decide to run more trials
             num_samples=-1,


### PR DESCRIPTION
## Issue

`find_best_model_config` post-processing crashed with
`AttributeError: 'NoneType' object has no attribute 'to_directory'`
when loading the best K-fold trainable from `nn_reg` / `nn_class` /
`nn_corn` / `xgb` / `xgb_class`.

**Root cause.** The K-fold path emits two report shapes per trial via
`_emit_running_fold_aggregate` + `_aggregate_fold_metrics`:

- K-1 mid-trial **running aggregates** (`tune.report(metrics=...)`,
  *no checkpoint*) so ASHA can prune at fold boundaries.
- 1 final post-refit report (`tune.report(metrics=...,
  checkpoint=<deployable>)`).

Both shapes set the bare `<metric>` key to the (running or final)
mean. The running aggregate after fold `i` is the mean over folds
`0..i`, while the final aggregate is the mean over all K folds — for
small / noisy K the early-fold mean can easily beat the all-K mean
(e.g. an `nn_class` trial scoring 0.9 ROC AUC on folds 0–1 then
0.7 on folds 2–4). Ray Tune's `get_best_result(metric=<metric>)`
returns the trial row with the best metric value, which can therefore
be a running-aggregate row whose `checkpoint` is `None`. The
downstream `load_nn_model` / `load_xgb_model` then dereferences
`result.checkpoint.to_directory()` and crashes.

Affects only checkpoint-based trainables; sklearn-style
(`linreg`/`logreg`/`rf`/`rf_class`) and `trac` are unaffected because
they persist via `result.metrics["model_path"]`. Surfaced on a smoke
run of `experiments/evaluate_trials_mlflow.ipynb` with
`task_type="classification"`: all 4 trainables trained cleanly, then
post-processing crashed loading the best `nn_class`.

## Changes

- **`_emit_running_fold_aggregate`** (`ritme/model_space/static_trainables.py`)
  strips bare metric keys (`<metric>`) from running-aggregate reports
  and keeps only the suffixed variants (`_mean`/`_std`/`_se`) plus
  `n_folds`/`nb_features`. Bare keys now live exclusively on the final
  post-refit report (which is the one carrying the deployable
  checkpoint), so `get_best_result(metric=<metric>)` can only land on a
  row with a checkpoint.
- **`_define_scheduler`** (`ritme/tune_models.py`) gained
  `metric`/`mode`/`k_folds` params. When `k_folds > 1` the scheduler
  monitors `<metric>_mean` (visible in both running and final
  aggregates), preserving ASHA pruning at fold boundaries; single-split
  keeps the bare `<metric>`.
- **`run_trials`** (`ritme/tune_models.py`) computes
  `runtime_metric = <metric>_mean if k_folds > 1 else <metric>` and
  passes it to both the scheduler and `OptunaSearch` (Ray Tune's strict
  metric validator enforces the search algo's metric on every report).
  `TuneConfig.metric` / `mode` are set to `None` because Ray Tune
  disallows both the Tuner and the scheduler specifying them.
- **`_select_best_with_one_se`** (`ritme/evaluate_models.py`) fallback
  now calls `result_grid.get_best_result(metric=metric, mode=mode,
  scope="all")` explicitly (`TuneConfig` no longer carries them).

## Testing

Full suite: **475 passed**.

Updated assertions:
- `test_emit_running_fold_aggregate_emits_growing_aggregate`: bare
  `rmse_val` is absent in running aggregates; `_mean`/`_std`/`_se`
  variants present.
- `test_train_xgb_kfold_emits_running_aggregate_per_fold`: same shape
  guard on the xgb path.
- `test_run_trials_classification`: `TuneConfig.metric/mode` are
  `None`; scheduler holds `roc_auc_macro_ovr_val` / `max`.
- `test_falls_back_to_get_best_when_no_se_present` /
  `test_falls_back_to_get_best_when_all_se_are_nan`: assert
  `get_best_result` is called with explicit `metric`/`mode`.

New tests:
- `test_define_scheduler_uses_mean_suffix_when_kfold` and
  `test_define_scheduler_uses_bare_metric_when_single_split` pin the
  scheduler metric across the K-fold branch.

Smoke run of `experiments/evaluate_trials_mlflow.ipynb` (classification
mode, `time_budget_s=180`/model, ~12 min): **0 cell errors**, all 4
trainables completed (`logreg` 50, `xgb_class` 49, `nn_class` 48,
`rf_class` 47 terminated trials), MLflow logs and best-model
checkpoints written, no `AttributeError`.

## Backwards compatibility

Internal report-shape change. Running-aggregate `tune.report` calls
no longer include bare metric keys; any external consumer reading
those via raw Ray-Tune trial reports would need to switch to the
suffixed variants. No public API change.
