### PR TITLE
ADD: Snapshot-mode smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ lightning_logs/
 
 # Sequence and metadata
 **/experiments/data/**
+# Re-allow the snapshot-mode dummy-data generator (deterministic, seeded;
+# regenerates ``{md,ft}_dummy_snapshot.tsv`` for the snapshot smoke test).
+!**/experiments/data/generate_dummy_snapshot_data.py
 
 # Any callgraphs
 **.svg
@@ -183,6 +186,7 @@ experiments/data_splits_mlflow
 experiments/data_splits_mlflow_class
 experiments/data_splits_wandb
 experiments/data_splits_ma2
+experiments/data_splits_snapshot
 experiments/best_models
 experiments/ritme_example_usage_all.ipynb
 experiments/ritme_example_usage_nn.ipynb
@@ -197,6 +201,7 @@ experiments/ritme_example_usage_nn.ipynb
 !trials_mlflow.json
 !trials_mlflow_class.json
 !trials_wandb.json
+!trials_snapshot.json
 
 # GHA secrets
 .secrets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,62 @@ ritme evaluate-tuned-models --help
 ### Testing
 - All new functionality must have corresponding tests in `ritme/tests/`.
 
+### Smoke tests
+Unit tests live in `ritme/tests/`; the smoke runs below exercise the
+full end-to-end pipeline (`split_train_test` -> `find_best_model_config`
+-> evaluation / SHAP) under different tracking sinks and data shapes.
+They are not part of CI -- run them locally after any change that
+touches Ray Tune integration (`tune_models.py`), feature engineering
+(`_process_train.py`, `enrich_features.py`), trainables
+(`model_space/`), or the CLI / shell scripts.
+
+**Always force a clean re-run** (the shell scripts skip steps when
+their outputs already exist):
+
+1. Delete the relevant data splits and log dirs:
+   ```bash
+   rm -rf experiments/data_splits_{mlflow,mlflow_class,wandb,snapshot}
+   rm -rf experiments/ritme_example_logs/{trials_mlflow,trials_mlflow_class,trials_wandb,trials_snapshot}
+   rm -rf experiments/ritme_example_logs/{example_linreg,example_linreg_py,example_logreg,example_logreg_py}
+   ```
+2. Lower the per-model time budget in the relevant config(s) so the
+   smoke finishes in minutes rather than hours -- e.g. set
+   `time_budget_s` to 60-180 in `config/trials_*.json`. Restore the
+   original value when done.
+3. Run the smoke (see table below).
+4. Verify the run actually executed -- check that the log dir was
+   created in this session:
+   ```bash
+   ls -la experiments/ritme_example_logs/<exp_tag>/   # mtime should be now
+   wc -l experiments/ritme_example_logs/<exp_tag>/mlflow_logs.csv
+   ```
+   A non-empty `mlflow_logs.csv` (or `wandb_logs.csv`) with a fresh
+   mtime confirms training actually ran. An empty / missing log file
+   means the shell script's "skip if non-empty" guard fired against
+   stale state -- repeat step 1 and retry.
+
+| Smoke | Command (from `experiments/`) | Covers | ETA at recommended budget |
+|-------|-------------------------------|--------|----------------------------|
+| Python API + CLI examples | execute `ritme_example_usage.ipynb` via `jupyter nbconvert --to notebook --execute ... --allow-errors` | `find_best_model_config` Python API + CLI, single-model linreg/logreg | ~9 min |
+| MLflow regression sweep | `./run_experiment_mlflow.sh` (default `regression`) followed by executing `evaluate_trials_mlflow.ipynb` | all 7 regression trainables incl. `nn_corn`, MLflow tracking, SHAP | ~20 min (`time_budget_s=180`/model) |
+| MLflow classification sweep | edit `task_type = "classification"` in `evaluate_trials_mlflow.ipynb` (or copy to a scratch ipynb) + run | `logreg`, `xgb_class`, `nn_class`, `rf_class`, K-fold `get_best_result` post-processing | ~12 min (`time_budget_s=180`/model) |
+| WandB regression sweep | `./run_experiment_wandb.sh` | `WandbLoggerCallback`, same `run_trials` / scheduler / metric plumbing as MLflow but the wandb tracking sink | ~10 min (`time_budget_s=60`/model) |
+| Snapshot / temporal mode | `./run_experiment_snapshot.sh` | `split_train_test` with `--time-col` / `--host-col` / `--n-prev`, the dynamic-mode `__t-N` column suffixing, K-fold + categorical-enrich on snapshot data | ~5 min (`time_budget_s=60`/model) |
+
+When a change is scoped to a specific path, the minimum required smoke is:
+
+- Ray Tune scheduler / metric / `get_best_result` plumbing
+  (`tune_models.py`, `evaluate_models.py`): MLflow classification +
+  WandB (different tracking sinks share the same plumbing).
+- Feature engineering (`feature_space/`): MLflow regression (small N,
+  `data_enrich_with` exercises the categorical-universe path) +
+  snapshot (temporal column suffixing).
+- Trainables (`model_space/static_trainables.py`): MLflow regression
+  (covers all 7 regression trainables) +
+  `ritme_example_usage.ipynb` (single-split path on linreg/logreg).
+- CLI wrappers (`split_train_test.py::cli_*`, `find_best_model_config.py::cli_*`,
+  etc.): `ritme_example_usage.ipynb` (CLI section runs each command).
+
 ### Formatting
 - Ensure all code is formatted according to the pre-commit hooks in this repos.
 

--- a/config/trials_snapshot.json
+++ b/config/trials_snapshot.json
@@ -1,0 +1,21 @@
+{
+  "experiment_tag": "trials_snapshot",
+  "fully_reproducible": true,
+  "group_by_column": "host_id",
+  "ls_model_types": [
+    "linreg",
+    "xgb"
+  ],
+  "max_cuncurrent_trials": 2,
+  "model_hyperparameters": {
+    "data_enrich_with": [
+      "body-site"
+    ]
+  },
+  "optuna_searchspace_sampler": "TPESampler",
+  "seed_data": 12,
+  "seed_model": 12,
+  "target": "target",
+  "time_budget_s": 60,
+  "tracking_uri": "mlruns"
+}

--- a/experiments/data/generate_dummy_snapshot_data.py
+++ b/experiments/data/generate_dummy_snapshot_data.py
@@ -1,0 +1,78 @@
+"""Generate a small synthetic snapshot-mode dataset for ritme smoke testing.
+
+Outputs:
+- md_dummy_snapshot.tsv: metadata with columns id, host_id, time, body-site, target
+- ft_dummy_snapshot.tsv: feature table with columns id, F1..F12 (relative abundances)
+
+Designed to exercise the dynamic / temporal-snapshot path:
+- ``host_col="host_id"`` -- 10 distinct hosts (>= 5 for K-fold-by-host)
+- ``time_col="time"`` -- 5 ordered integer time points per host
+- ``body-site`` -- a 3-level categorical so ``data_enrich_with`` exercises
+  the K-fold + categorical-universe dummy alignment fix
+- ``target`` -- continuous, regressable
+
+Total rows: 50 (10 hosts x 5 time points). After snapshotting with
+``n_prev=1`` and ``missing_mode="exclude"`` 40 rows survive (drop the
+first time point per host).
+
+Run from this directory:
+    python generate_dummy_snapshot_data.py
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+def main(
+    out_dir: str | os.PathLike = Path(__file__).parent,
+    n_hosts: int = 10,
+    n_times: int = 5,
+    n_features: int = 12,
+    seed: int = 42,
+) -> None:
+    rng = np.random.default_rng(seed)
+    body_sites = np.array(["gut", "tongue", "palm"])
+
+    rows_md = []
+    rows_ft = []
+    sample_idx = 0
+    for h in range(n_hosts):
+        # Each host gets a stable "lifestyle" body-site, drawn once.
+        bs = body_sites[rng.integers(0, len(body_sites))]
+        for t in range(n_times):
+            sample_idx += 1
+            sid = f"S{sample_idx:03d}"
+            # Per-sample Dirichlet relative abundances.
+            ft = rng.dirichlet(alpha=np.ones(n_features) * 0.5)
+            # Target depends on a couple of current features + small noise.
+            target = float(0.4 + 0.8 * ft[0] + 1.5 * ft[2] + rng.normal(0, 0.05))
+            rows_md.append(
+                {
+                    "id": sid,
+                    "host_id": f"h{h:02d}",
+                    "time": int(t),
+                    "body-site": bs,
+                    "target": target,
+                }
+            )
+            rows_ft.append(
+                {"id": sid, **{f"F{i + 1}": ft[i] for i in range(n_features)}}
+            )
+
+    md = pd.DataFrame(rows_md).set_index("id")
+    ft = pd.DataFrame(rows_ft).set_index("id")
+
+    out = Path(out_dir)
+    md.to_csv(out / "md_dummy_snapshot.tsv", sep="\t")
+    ft.to_csv(out / "ft_dummy_snapshot.tsv", sep="\t")
+    print(f"Wrote {out / 'md_dummy_snapshot.tsv'} ({md.shape})")
+    print(f"Wrote {out / 'ft_dummy_snapshot.tsv'} ({ft.shape})")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/run_experiment_snapshot.sh
+++ b/experiments/run_experiment_snapshot.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Snapshot / temporal-mode smoke test for ritme.
+#
+# Generates a small synthetic dataset (10 hosts x 5 time points x 12
+# features), runs ``ritme split-train-test`` in temporal mode
+# (``--time-col time --host-col host_id --n-prev 1``), then trains
+# linreg + xgb via ``ritme find-best-model-config``. Designed for a
+# ~5-7 min wall-clock smoke run.
+#
+# Re-runs are no-ops if the data, splits, and logs are all already
+# present. To force a clean re-run, delete:
+#   experiments/data/{md,ft}_dummy_snapshot.tsv
+#   experiments/data_splits_snapshot/
+#   experiments/ritme_example_logs/trials_snapshot/
+
+set -e
+
+# Generate synthetic snapshot dataset if either file is missing.
+if [[ ! -f data/md_dummy_snapshot.tsv || ! -f data/ft_dummy_snapshot.tsv ]]; then
+  python data/generate_dummy_snapshot_data.py
+fi
+
+# Snapshot-aware split: --time-col / --host-col / --n-prev trigger the
+# temporal-snapshot path in split_train_test, producing ``__t-1``-suffixed
+# columns on top of the unsuffixed (t0) ones.
+if [[ ! -f data_splits_snapshot/train_val.pkl ]]; then
+  ritme split-train-test \
+    data_splits_snapshot data/md_dummy_snapshot.tsv data/ft_dummy_snapshot.tsv \
+    --seed 12 \
+    --group-by-column host_id \
+    --time-col time \
+    --host-col host_id \
+    --n-prev 1 \
+    --missing-mode exclude
+fi
+
+# Run find-best-model-config only if the experiment dir is empty.
+if [[ -z "$(find ritme_example_logs/trials_snapshot -maxdepth 1 -mindepth 1 -print -quit 2>/dev/null)" ]]; then
+  ritme find-best-model-config \
+    ../config/trials_snapshot.json data_splits_snapshot/train_val.pkl \
+    --path-store-model-logs ritme_example_logs
+else
+  echo "trials_snapshot directory is not empty; not running find-best-model-config again."
+fi


### PR DESCRIPTION
## Summary

Adds a reusable end-to-end smoke test for the temporal / snapshot path
(`split_train_test --time-col --host-col --n-prev`), which was not
exercised by any of the shipped notebooks. Also documents the full set
of smoke tests (MLflow regression, MLflow classification, WandB,
example-usage notebook, snapshot) in `AGENTS.md`, including how to
force a clean re-run and how to confirm the run actually executed
(catches the "shell script silently skipped because logs already exist"
failure mode).

## Changes

- **`experiments/data/generate_dummy_snapshot_data.py`** (new):
  deterministic seeded generator. 10 hosts × 5 time points × 12
  Dirichlet features + a 3-level `body-site` categorical so the
  K-fold + `data_enrich_with` dummy-alignment path is exercised. 50
  rows total; 40 survive after `n_prev=1` snapshotting with
  `missing_mode=exclude`.
- **`config/trials_snapshot.json`** (new): small snapshot-mode config
  -- `linreg` + `xgb`, `time_budget_s=60`, `data_enrich_with:
  ["body-site"]`, MLflow tracking.
- **`experiments/run_experiment_snapshot.sh`** (new): orchestrator
  shell script mirroring `run_experiment_mlflow.sh` (skip-if-exists
  guards at each step). Run from `experiments/`.
- **`AGENTS.md`**: new "Smoke tests" subsection under Testing -- a
  table mapping the 5 smoke entry points to what each covers and its
  ETA, the clean-slate `rm -rf` recipe, the freshness check
  (`ls -la <log_dir>` mtime + `wc -l mlflow_logs.csv`), and a "minimum
  required smoke per change scope" matrix (Ray Tune plumbing,
  feature engineering, trainables, CLI).
- **`.gitignore`**: exceptions so the snapshot-smoke artifacts above
  are trackable (`!**/experiments/data/generate_dummy_snapshot_data.py`,
  `!trials_snapshot.json`), and `experiments/data_splits_snapshot`
  added alongside the other ignored `data_splits_*` dirs.

## Verification

Snapshot smoke ran end-to-end in ~5 min wall on the synthetic dataset:
`linreg` 17 TERMINATED, `xgb` 17 TERMINATED, MLflow logs and best-model
checkpoints written, no trial errors.

Full unit suite unchanged (475 passed).
