### PR TITLE
ENH: NaN-tolerance whitelist + eager data_enrich NaN validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ When testing new functionality always do it in an activated conda environment ca
 - **Compositionality per snapshot**: Microbial features within a single time point are compositional. Transforms (CLR/ILR/ALR) are applied per snapshot, never across time points.
 - **No data leakage**: Feature engineering parameters (selection, ALR denominator, enrichment schema) are learned on train and reused as-is on test via `TunedModel` state.
 - **TRAC incompatibility**: TRAC requires a single compositional snapshot + phylogenetic tree. It is automatically excluded when dynamic snapshots are detected.
-- **NaN handling**: `missing_mode="nan"` requires `ls_model_types` to contain only XGBoost; requesting any other model raises a `ValueError`. NaN rows are separated before compositional transforms and reintroduced afterward.
+- **NaN handling**: `missing_mode="nan"` restricts `ls_model_types` to the NaN-tolerant set; requesting any other model raises a `ValueError`. Numeric `data_enrich_with` columns are validated against the same set at config-resolution time. NaN rows are separated before compositional transforms and reintroduced afterward.
 - **Column naming**: Past snapshots are suffixed (`F0__t-1`, `age__t-2`); current (t0) columns remain unsuffixed. This ensures backward compatibility with the static workflow.
 - **K-fold cross-validation**: Trainables default to 5-fold cross-validation (adaptively capped by group count and smallest stratum; `k_folds: 1` opts out) and `find_best_model_config` selects the best configuration using a one-standard-error rule on the per-fold metric.
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - conda-forge::ray-default >=2.54
     - conda-forge::ray-tune >=2.54
     - scikit-bio
-    - scikit-learn
+    - scikit-learn >=1.4
     - scipy
     - conda-forge::seaborn
     - conda-forge::shap

--- a/ritme/find_best_model_config.py
+++ b/ritme/find_best_model_config.py
@@ -14,7 +14,11 @@ from ritme.evaluate_models import (
 )
 from ritme.feature_space.utils import _PAST_SUFFIX_RE
 from ritme.split_train_test import adaptive_k_folds
-from ritme.tune_models import DEFAULT_NN_CORN_MAX_LEVELS, run_all_trials
+from ritme.tune_models import (
+    DEFAULT_NN_CORN_MAX_LEVELS,
+    NAN_TOLERANT_MODELS,
+    run_all_trials,
+)
 
 
 # ----------------------------------------------------------------------------
@@ -35,6 +39,65 @@ def _verify_experiment_config(config: dict):
             f"Invalid tracking_uri: {config['tracking_uri']}. Must be "
             f"'mlruns' or 'wandb'."
         )
+
+
+_METADATA_ENRICH_MODES = frozenset({"metadata_only", "shannon_and_metadata"})
+
+
+@helper_function
+def _verify_data_enrich_compat(config: dict, train_val: pd.DataFrame) -> None:
+    """
+    Fail fast when ``data_enrich_with`` may inject NaN-bearing numeric
+    metadata into the feature matrix and an intolerant trainable is
+    requested -- so the search aborts at config time instead of crashing
+    inside a trial.
+
+    Mirrors ``ritme.model_space.static_searchspace.get_data_eng_space``:
+    ``data_enrich_with`` and ``data_enrich_options`` both live under
+    ``config["model_hyperparameters"]``. Categorical / object enrich
+    columns are skipped because ``enrich_features`` one-hot encodes them
+    with ``pd.get_dummies``, which collapses NaN to all-zero indicators.
+    """
+    mh = config.get("model_hyperparameters") or {}
+    enrich_cols = mh.get("data_enrich_with") or []
+    if not enrich_cols:
+        return
+
+    # Match the per-trial sampling logic: when ``data_enrich_options`` is
+    # not set, the default option set (with metadata columns present)
+    # includes the two metadata-injecting modes.
+    enrich_options = mh.get("data_enrich_options")
+    if enrich_options is not None and not any(
+        opt in _METADATA_ENRICH_MODES for opt in enrich_options
+    ):
+        return
+
+    intolerant = sorted(set(config.get("ls_model_types", [])) - NAN_TOLERANT_MODELS)
+    if not intolerant:
+        return
+
+    nan_counts = {
+        col: int(train_val[col].isna().sum())
+        for col in enrich_cols
+        # Missing columns are validated downstream by
+        # ``enrich_features`` with its own ValueError. Categorical /
+        # object columns route through ``pd.get_dummies`` and never
+        # propagate NaN, so they are safe regardless of NaN content.
+        if col in train_val.columns
+        and pd.api.types.is_numeric_dtype(train_val[col])
+        and train_val[col].isna().any()
+    }
+    if not nan_counts:
+        return
+
+    nan_summary = ", ".join(f"{col!r}={n}" for col, n in nan_counts.items())
+    raise ValueError(
+        f"data_enrich_with numeric columns contain NaN ({nan_summary}); "
+        f"requested model types {intolerant} do not support NaN inputs. "
+        f"Impute or drop the affected samples in metadata before running "
+        f"the search, or restrict ls_model_types to "
+        f"{sorted(NAN_TOLERANT_MODELS)}."
+    )
 
 
 @helper_function
@@ -222,6 +285,7 @@ def find_best_model_config(
         str: Path to the experiment folder.
     """
     _verify_experiment_config(config)
+    _verify_data_enrich_compat(config, train_val)
 
     # ! Define needed paths
     path_exp = _define_experiment_path(config, path_store_model_logs)

--- a/ritme/tests/test_find_best_model_config.py
+++ b/ritme/tests/test_find_best_model_config.py
@@ -6,6 +6,7 @@ import unittest
 from io import StringIO
 from unittest.mock import ANY, MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import skbio
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -20,6 +21,7 @@ from ritme.find_best_model_config import (
     _process_phylogeny,
     _process_taxonomy,
     _save_config,
+    _verify_data_enrich_compat,
     _verify_experiment_config,
     cli_find_best_model_config,
     find_best_model_config,
@@ -107,6 +109,121 @@ class TestFindBestModelConfig(unittest.TestCase):
         config["tracking_uri"] = "invalid"
         with self.assertRaises(ValueError):
             _verify_experiment_config(config)
+
+    def _make_enrich_data(self, bmi_values=(22.0, 23.0, 24.0), site_values=None):
+        if site_values is None:
+            site_values = ["gut", "skin", "gut"]
+        return pd.DataFrame(
+            {
+                "F1": [0.1, 0.2, 0.3],
+                "F2": [0.4, 0.5, 0.6],
+                "bmi": list(bmi_values),
+                "body-site": pd.Series(site_values, dtype="object"),
+                "target_column": [1.0, 2.0, 3.0],
+            }
+        )
+
+    @staticmethod
+    def _enrich_config(
+        *,
+        data_enrich_with,
+        ls_model_types,
+        data_enrich_options=None,
+        model_hyperparameters_extra=None,
+    ):
+        mh = dict(model_hyperparameters_extra or {})
+        if data_enrich_with is not None:
+            mh["data_enrich_with"] = data_enrich_with
+        if data_enrich_options is not None:
+            mh["data_enrich_options"] = data_enrich_options
+        return {
+            "ls_model_types": list(ls_model_types),
+            "model_hyperparameters": mh,
+        }
+
+    def test_verify_data_enrich_compat_no_enrich_with(self):
+        # No data_enrich_with means no metadata is injected, so the
+        # validator must not fire regardless of requested models.
+        for value in (None, []):
+            with self.subTest(data_enrich_with=value):
+                config = self._enrich_config(
+                    data_enrich_with=value, ls_model_types=["linreg"]
+                )
+                train_val = self._make_enrich_data(bmi_values=[22.0, np.nan, 24.0])
+                _verify_data_enrich_compat(config, train_val)
+        empty_mh_config = {
+            "ls_model_types": ["linreg"],
+            "model_hyperparameters": {},
+        }
+        _verify_data_enrich_compat(empty_mh_config, self._make_enrich_data())
+
+    def test_verify_data_enrich_compat_options_exclude_metadata(self):
+        # data_enrich_options explicitly restricted to non-metadata modes ->
+        # no NaN can reach the trainable, so validator no-ops.
+        config = self._enrich_config(
+            data_enrich_with=["bmi"],
+            ls_model_types=["linreg"],
+            data_enrich_options=[None, "shannon"],
+        )
+        train_val = self._make_enrich_data(bmi_values=[22.0, np.nan, 24.0])
+        _verify_data_enrich_compat(config, train_val)
+
+    def test_verify_data_enrich_compat_no_nan(self):
+        config = self._enrich_config(
+            data_enrich_with=["bmi"], ls_model_types=["linreg"]
+        )
+        _verify_data_enrich_compat(config, self._make_enrich_data())
+
+    def test_verify_data_enrich_compat_only_tolerant_models(self):
+        config = self._enrich_config(
+            data_enrich_with=["bmi"], ls_model_types=["xgb", "rf"]
+        )
+        train_val = self._make_enrich_data(bmi_values=[22.0, np.nan, 24.0])
+        _verify_data_enrich_compat(config, train_val)
+
+    def test_verify_data_enrich_compat_categorical_with_nan_passes(self):
+        # body-site is object/categorical -> enrich_features one-hots it via
+        # pd.get_dummies, which never propagates NaN to the feature matrix.
+        config = self._enrich_config(
+            data_enrich_with=["body-site"], ls_model_types=["linreg"]
+        )
+        train_val = self._make_enrich_data(site_values=["gut", None, "skin"])
+        _verify_data_enrich_compat(config, train_val)
+
+    def test_verify_data_enrich_compat_raises_with_nan_and_intolerant(self):
+        config = self._enrich_config(
+            data_enrich_with=["bmi"], ls_model_types=["xgb", "linreg"]
+        )
+        train_val = self._make_enrich_data(bmi_values=[22.0, np.nan, np.nan])
+        with self.assertRaises(ValueError) as ctx:
+            _verify_data_enrich_compat(config, train_val)
+        msg = str(ctx.exception)
+        self.assertIn("bmi", msg)
+        self.assertRegex(msg, r"'bmi'\D*\b2\b")
+        # xgb is tolerant: must NOT appear in the intolerant-models list
+        # (it still appears in the remediation suggestion downstream).
+        self.assertRegex(msg, r"requested model types \[[^\]]*'linreg'[^\]]*\]")
+        self.assertNotRegex(msg, r"requested model types \[[^\]]*'xgb'[^\]]*\]")
+
+    def test_verify_data_enrich_compat_multi_column_summary(self):
+        train_val = self._make_enrich_data(bmi_values=[22.0, np.nan, np.nan])
+        train_val["age"] = [np.nan, 30.0, 40.0]
+        config = self._enrich_config(
+            data_enrich_with=["bmi", "age"], ls_model_types=["linreg"]
+        )
+        with self.assertRaises(ValueError) as ctx:
+            _verify_data_enrich_compat(config, train_val)
+        msg = str(ctx.exception)
+        self.assertRegex(msg, r"'bmi'\D*\b2\b")
+        self.assertRegex(msg, r"'age'\D*\b1\b")
+
+    def test_verify_data_enrich_compat_skips_missing_columns(self):
+        # Columns absent from train_val are delegated to enrich_features
+        # (see enrich_features.py:46-52) which raises its own ValueError.
+        config = self._enrich_config(
+            data_enrich_with=["not_in_df"], ls_model_types=["linreg"]
+        )
+        _verify_data_enrich_compat(config, self._make_enrich_data())
 
     def test_save_config(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -208,6 +325,38 @@ class TestFindBestModelConfig(unittest.TestCase):
                 ValueError, f"already exists: {self.config['experiment_tag']}."
             ):
                 _define_experiment_path(self.config, temp_dir)
+
+    @patch("ritme.find_best_model_config.run_all_trials")
+    def test_find_best_model_config_aborts_on_enrich_nan_before_path_creation(
+        self, mock_run_all_trials
+    ):
+        # End-to-end wiring: the validator must fire before run_all_trials
+        # is invoked AND before _define_experiment_path creates the log
+        # directory on disk.
+        config = self.config.copy()
+        config["ls_model_types"] = ["linreg"]
+        config["model_hyperparameters"] = {"data_enrich_with": ["bmi"]}
+        train_val = self.train_val.copy()
+        train_val["bmi"] = [
+            22.0,
+            np.nan,
+            24.0,
+            25.0,
+            26.0,
+            27.0,
+            28.0,
+            29.0,
+            30.0,
+            31.0,
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ValueError, r"data_enrich_with"):
+                find_best_model_config(config, train_val, None, None, temp_dir)
+            mock_run_all_trials.assert_not_called()
+            self.assertFalse(
+                os.path.exists(os.path.join(temp_dir, config["experiment_tag"]))
+            )
 
     @patch("ritme.find_best_model_config._extract_mlflow_logs_to_csv")
     @patch("ritme.find_best_model_config.run_all_trials")

--- a/ritme/tests/test_tune_models.py
+++ b/ritme/tests/test_tune_models.py
@@ -18,6 +18,7 @@ from ray.tune.search.optuna import OptunaSearch
 from ritme.model_space import static_searchspace as ss
 from ritme.tune_models import (
     MODEL_TRAINABLES,
+    NAN_TOLERANT_MODELS,
     OPTUNA_SAMPLER_CLASSES,
     _adaptive_n_startup_trials,
     _check_for_errors_in_trials,
@@ -50,6 +51,13 @@ class TestHelpersTuneModels(unittest.TestCase):
     def test_get_slurm_resource_invalid(self):
         # Test when the environment variable is invalid
         self.assertEqual(_get_slurm_resource("SLURM_CPUS_PER_TASK"), 0)
+
+    def test_nan_tolerant_models_constant(self):
+        # Guard against silent shrinking of the NaN-tolerant whitelist.
+        self.assertEqual(
+            NAN_TOLERANT_MODELS,
+            frozenset({"xgb", "xgb_class", "rf", "rf_class"}),
+        )
 
     def test_check_for_errors_in_trials_no_errors(self):
         # Mock ResultGrid with no errors
@@ -507,8 +515,9 @@ class TestMainTuneModels(unittest.TestCase):
         self.assertNotIn("trac", results)
 
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_rejects_non_xgb(self, mock_run_trials):
-        # dataframe with NaN in snapshot features
+    def test_run_all_trials_nan_snapshots_rejects_non_nan_tolerant(
+        self, mock_run_trials
+    ):
         self.train_val = pd.DataFrame(
             {
                 "F1": [0.1, 0.2],
@@ -522,8 +531,8 @@ class TestMainTuneModels(unittest.TestCase):
         )
         mock_result = MagicMock(spec=ResultGrid)
         mock_run_trials.return_value = mock_result
-        model_types = ["xgb", "rf", "trac"]
-        with self.assertRaisesRegex(ValueError, r"NaNs in snapshot features"):
+        model_types = ["xgb", "rf", "linreg", "trac"]
+        with self.assertRaises(ValueError) as ctx:
             run_all_trials(
                 train_val=self.train_val,
                 target=self.target,
@@ -541,11 +550,27 @@ class TestMainTuneModels(unittest.TestCase):
                 model_types=model_types,
                 model_hyperparameters=self.model_hyperparameters,
             )
+        msg = str(ctx.exception)
+        self.assertIn("NaNs in snapshot features", msg)
+        # Regression task: allowed list must mention rf+xgb and NOT the
+        # *_class counterparts.
+        self.assertIn("'xgb'", msg)
+        self.assertIn("'rf'", msg)
+        self.assertNotIn("'xgb_class'", msg)
+        self.assertNotIn("'rf_class'", msg)
         mock_run_trials.assert_not_called()
 
+    @parameterized.expand(
+        [
+            (["xgb"],),
+            (["rf"],),
+            (["xgb", "rf"],),
+        ]
+    )
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_xgb_only_ok(self, mock_run_trials):
-        # dataframe with NaN in snapshot features; only xgb requested
+    def test_run_all_trials_nan_snapshots_xgb_or_rf_ok(
+        self, model_types, mock_run_trials
+    ):
         self.train_val = pd.DataFrame(
             {
                 "F1": [0.1, 0.2],
@@ -573,10 +598,10 @@ class TestMainTuneModels(unittest.TestCase):
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
             experiment_tag=self.experiment_tag,
-            model_types=["xgb"],
+            model_types=list(model_types),
             model_hyperparameters=self.model_hyperparameters,
         )
-        self.assertEqual(list(results.keys()), ["xgb"])
+        self.assertEqual(sorted(results.keys()), sorted(model_types))
 
     @patch("ritme.tune_models.init")
     @patch("ritme.tune_models.ray.cluster_resources")
@@ -678,8 +703,9 @@ class TestMainTuneModels(unittest.TestCase):
             self.assertEqual(call.kwargs.get("task_type"), "classification")
 
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_rejects_non_xgb_class(self, mock_run_trials):
-        # dataframe with NaN in snapshot features
+    def test_run_all_trials_nan_snapshots_rejects_non_nan_tolerant_class(
+        self, mock_run_trials
+    ):
         self.train_val = pd.DataFrame(
             {
                 "F1": [0.1, 0.2],
@@ -692,7 +718,7 @@ class TestMainTuneModels(unittest.TestCase):
             }
         )
         model_types = ["xgb_class", "rf_class", "logreg"]
-        with self.assertRaisesRegex(ValueError, r"NaNs in snapshot features"):
+        with self.assertRaises(ValueError) as ctx:
             run_all_trials(
                 train_val=self.train_val,
                 target=self.target,
@@ -711,11 +737,27 @@ class TestMainTuneModels(unittest.TestCase):
                 model_hyperparameters=self.model_hyperparameters,
                 task_type="classification",
             )
+        msg = str(ctx.exception)
+        self.assertIn("NaNs in snapshot features", msg)
+        # Classification task: allowed list must mention *_class
+        # counterparts and NOT the bare regression names.
+        self.assertIn("'xgb_class'", msg)
+        self.assertIn("'rf_class'", msg)
+        self.assertNotIn("'xgb'", msg)
+        self.assertNotIn("'rf'", msg)
         mock_run_trials.assert_not_called()
 
+    @parameterized.expand(
+        [
+            (["xgb_class"],),
+            (["rf_class"],),
+            (["xgb_class", "rf_class"],),
+        ]
+    )
     @patch("ritme.tune_models.run_trials")
-    def test_run_all_trials_nan_snapshots_xgb_class_only_ok(self, mock_run_trials):
-        # dataframe with NaN in snapshot features; only xgb_class requested
+    def test_run_all_trials_nan_snapshots_xgb_class_or_rf_class_ok(
+        self, model_types, mock_run_trials
+    ):
         self.train_val = pd.DataFrame(
             {
                 "F1": [0.1, 0.2],
@@ -743,11 +785,11 @@ class TestMainTuneModels(unittest.TestCase):
             time_budget_s=self.time_budget_s,
             max_concurrent_trials=self.max_concurrent_trials,
             experiment_tag=self.experiment_tag,
-            model_types=["xgb_class"],
+            model_types=list(model_types),
             model_hyperparameters=self.model_hyperparameters,
             task_type="classification",
         )
-        self.assertEqual(list(results.keys()), ["xgb_class"])
+        self.assertEqual(sorted(results.keys()), sorted(model_types))
 
     @patch("ritme.tune_models.run_trials")
     def test_run_all_trials_classification_hparams_fallback_rf_class(

--- a/ritme/tune_models.py
+++ b/ritme/tune_models.py
@@ -45,6 +45,11 @@ MODEL_TRAINABLES = {
 REGRESSION_MODELS = {"xgb", "nn_reg", "linreg", "rf", "trac", "nn_corn"}
 CLASSIFICATION_MODELS = {"xgb_class", "nn_class", "logreg", "rf_class"}
 
+# Trainables that accept NaN-bearing inputs without preprocessing.
+# - xgb/xgb_class: native NaN handling in DMatrix
+# - rf/rf_class:   sklearn >= 1.4 RandomForest splitter accepts NaN
+NAN_TOLERANT_MODELS = frozenset({"xgb", "xgb_class", "rf", "rf_class"})
+
 # Re-export so callers can keep importing the cap constant from ``tune_models``
 # without learning about its physical home in ``static_trainables``.
 DEFAULT_NN_CORN_MAX_LEVELS = st.DEFAULT_NN_CORN_MAX_LEVELS
@@ -643,16 +648,20 @@ def run_all_trials(
         else False
     )
     if has_snapshots and has_snapshot_nans:
-        # Only xgb/xgb_class support native NaN handling; reject any other request
-        xgb_model = "xgb_class" if task_type == "classification" else "xgb"
-        incompatible = sorted(set(model_types) - {xgb_model})
+        task_models = (
+            CLASSIFICATION_MODELS
+            if task_type == "classification"
+            else REGRESSION_MODELS
+        )
+        allowed = sorted(NAN_TOLERANT_MODELS & task_models)
+        incompatible = sorted(set(model_types) - set(allowed))
         if incompatible:
             raise ValueError(
-                f"NaNs in snapshot features detected (missing_mode='nan'); only "
-                f"'{xgb_model}' supports native NaN handling. Requested model "
-                f"types {incompatible} are incompatible. Either set "
+                f"NaNs in snapshot features detected (missing_mode='nan'); "
+                f"only {allowed} support native NaN handling. Requested "
+                f"model types {incompatible} are incompatible. Either set "
                 f"missing_mode='exclude' in split_train_test or restrict "
-                f"ls_model_types to ['{xgb_model}']."
+                f"ls_model_types to {allowed}."
             )
     elif has_snapshots and "trac" in model_types:
         # Remove trac when dynamic snapshots present


### PR DESCRIPTION
Two related NaN-handling defects keep users from running
`find-best-model-config` smoothly on real data:

1. `tune_models.py` rejects every trainable except `xgb`/`xgb_class` when
   `missing_mode='nan'` introduces NaN into snapshot columns. sklearn ≥
   1.4 added native NaN handling to `RandomForest*` — confirmed
   empirically on the test cluster (sklearn 1.8.0), where `rf_class`
   completes end-to-end on data with a single NaN cell.
2. When a trial samples `data_enrich="metadata_only"` or
   `"shannon_and_metadata"`, numeric columns listed in
   `data_enrich_with` are appended verbatim to the feature matrix. If
   they carry NaN and the chosen trainables can't handle it, the search
   burns hours of compute before crashing inside a trial — there's no
   eager validation today.

Both bugs depend on the same predicate ("which trainables accept NaN
inputs"), so a single source of truth (`NAN_TOLERANT_MODELS`) now
backs both validators.

## What changed

- **`ritme/tune_models.py`**: new module-level `NAN_TOLERANT_MODELS =
  frozenset({"xgb", "xgb_class", "rf", "rf_class"})`. The snapshot NaN
  gate (formerly `xgb`-only) now intersects with the existing
  `REGRESSION_MODELS` / `CLASSIFICATION_MODELS` constants for the
  task-relevant subset, and the error message surfaces it (`['rf',
  'xgb']` for regression, `['rf_class', 'xgb_class']` for
  classification).
- **`ritme/find_best_model_config.py`**: new `_verify_data_enrich_compat`
  helper reads `data_enrich_with` and `data_enrich_options` from
  `config["model_hyperparameters"]` (matching
  `static_searchspace.get_data_eng_space`), raises a clear `ValueError`
  before `_define_experiment_path` runs (so no stub log directory is
  left behind) when a trial can sample a metadata-injecting enrich mode
  AND a listed numeric column carries NaN AND any requested trainable
  is intolerant. Categorical/object enrich columns are skipped because
  `enrich_features` one-hots them via `pd.get_dummies`, which never
  propagates NaN.
- **`ci/recipe/meta.yaml`**: pin `scikit-learn >=1.4` so the conda
  recipe's resolved environment cannot regress to a version without RF
  NaN support. (ritme is conda-first; `setup.py` deliberately ships no
  `install_requires`, and `make install` runs `pip install . --no-deps`.)
- **`AGENTS.md`**: NaN-handling design constraint updated to reflect
  the broadened whitelist and the new config-time validator.
- **`ritme/tests/test_tune_models.py`**: snapshot-NaN tests renamed and
  parameterised — rejection tests now use mixed tolerant+intolerant
  model lists and assert the task-specific allowed list appears in the
  error message; positive tests parameterise over `["xgb"] / ["rf"] /
  ["xgb", "rf"]` (and the classification mirror). New
  `test_nan_tolerant_models_constant` guards the whitelist shape.
- **`ritme/tests/test_find_best_model_config.py`**: eight tests for
  `_verify_data_enrich_compat` — empty/missing `data_enrich_with`,
  options-exclude-metadata, no-NaN, tolerant-only models, categorical
  column with NaN (passes), single-column raises, multi-column NaN
  summary, missing-column silent skip. Plus an end-to-end wiring test
  (`test_find_best_model_config_aborts_on_enrich_nan_before_path_creation`)
  that calls `find_best_model_config` with `run_all_trials` mocked and
  asserts (a) `ValueError` raised, (b) `run_all_trials` never invoked,
  (c) no experiment directory created on disk.

## Test plan

- [x] `ruff check` — passes repo-wide.
- [x] `py.test ritme/tests/test_tune_models.py ritme/tests/test_find_best_model_config.py` — 99 tests + 8 subtests pass.
- [x] Full `py.test` — 489 passed, no regressions.
- [x] Snapshot smoke with `missing_mode='nan'` + `ls_model_types=["rf", "xgb"]` (synthetic 10-host × 5-timepoint dataset, 112 NaN cells in `__t-1` columns of `train_val`): `rf` ran 14 trials, `xgb` ran 16, all status=FINISHED, best `rf` rmse_val_mean ≈ 0.164, best `xgb` ≈ 0.111, both `rf_best_model.pkl` and `xgb_best_model.pkl` saved.
