### PR TITLE
FIX: `find-best-model-config` crash when the best-scoring trial has no checkpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,5 +181,5 @@ When a change is scoped to a specific path, the minimum required smoke is:
 - AI attribution is mandatory: include `Co-Authored-By: <tool>` in commit trailers.
 
 ### Writing style
-- When writing documentation (e.g. in README files) - make sure the text is concise and does not contain unnecessary legacy/context information that is not crucial for the comment being made.
+- When writing documentation/text/comments or similar (e.g. in README files) - make sure the text is concise and does not contain unnecessary legacy/context information that is not crucial for the comment being made.
 - Do not transplant conversational rationale into the document. If you justified a change in chat (e.g. "this works because tool X reads file Y..."), the file itself should still only state *what* the reader needs to do. If they want the rationale, upstream tool docs are the right place to send them.

--- a/ritme/evaluate_models.py
+++ b/ritme/evaluate_models.py
@@ -109,6 +109,14 @@ def get_model(model_type: str, result: Result) -> Any:
     return model
 
 
+# Model types whose deployable artifact is a Ray Tune checkpoint (loaded via
+# ``_get_checkpoint_path`` -> ``load_xgb_model`` / ``load_nn_model``) rather than
+# an sklearn / trac model persisted to ``model_path``. A crashed trial of these
+# types can land in the ResultGrid with a reported metric but ``checkpoint is
+# None``; selecting it crashes the loader (issue #123).
+_CHECKPOINT_MODEL_TYPES = {"xgb", "xgb_class", "nn_reg", "nn_class", "nn_corn"}
+
+
 def get_taxonomy(result: Result) -> pd.DataFrame:
     """
     Retrieve the taxonomy DataFrame from the result object.
@@ -513,6 +521,48 @@ def _trial_simplicity_key(
     return (primary, *secondary)
 
 
+def _metric_value(result: Result, metric: str):
+    """Selection score for a trial: ``<metric>_mean`` if present, else ``<metric>``."""
+    m = result.metrics or {}
+    return m.get(f"{metric}_mean", m.get(metric))
+
+
+def _drop_checkpointless_trials(
+    result_grid, metric: str, model_type: str
+) -> List[Result]:
+    """Return only trials that carry a deployable checkpoint.
+
+    A trial that reported ``metric`` but crashed before persisting a checkpoint
+    (OOM kill, SIGSEGV, node loss mid-training) is kept in the ``ResultGrid``
+    with ``result.checkpoint is None``; selecting it crashes the checkpoint
+    loader (issue #123). Drop such trials -- warning per skipped trial with its
+    metric and Ray error status -- and raise if none remain deployable.
+    """
+    deployable = []
+    for result in result_grid:
+        if result.checkpoint is not None:
+            deployable.append(result)
+            continue
+        value = _metric_value(result, metric)
+        if value is None or (isinstance(value, float) and np.isnan(value)):
+            # Never reported the metric -> not a selection candidate anyway.
+            continue
+        warnings.warn(
+            f"Skipping '{model_type}' trial with {metric}={value}: it reported a "
+            f"metric but saved no checkpoint, so it crashed mid-training before "
+            f"persisting one (Ray status: {result.error or 'no error recorded'}).",
+            stacklevel=2,
+        )
+    if not deployable:
+        raise RuntimeError(
+            f"No '{model_type}' trial saved a deployable checkpoint: every trial "
+            f"crashed before persisting one (e.g. OOM kill, SIGSEGV, or node "
+            f"failure). Inspect the sweep logs for worker failures and re-run "
+            f"with more memory per trial or fewer concurrent trials."
+        )
+    return deployable
+
+
 def _select_best_with_one_se(
     result_grid,
     metric: str,
@@ -529,10 +579,21 @@ def _select_best_with_one_se(
     Trials without a finite ``<metric>_se`` (single-split runs, or K-fold
     runs that had K-1 NaN folds) are excluded from selection. If no trial
     has a finite SE, defers to ``ResultGrid.get_best_result(scope='all')``.
+
+    For checkpoint-based trainables (see ``_CHECKPOINT_MODEL_TYPES``), trials
+    that crashed before saving a checkpoint are dropped first so a
+    non-deployable trial can never be selected as best (issue #123).
     """
     sign = 1 if mode == "min" else -1
+    # Exclude crashed, checkpoint-less trials up front for checkpoint-based
+    # trainables; sklearn / trac models keep their full grid (their artifact is
+    # ``model_path``, so ``checkpoint is None`` is expected and not a failure).
+    if model_type in _CHECKPOINT_MODEL_TYPES:
+        results = _drop_checkpointless_trials(result_grid, metric, model_type)
+    else:
+        results = result_grid
     candidates = []
-    for result in result_grid:
+    for result in results:
         m = result.metrics or {}
         mean = m.get(f"{metric}_mean", m.get(metric))
         se = m.get(f"{metric}_se")
@@ -546,10 +607,22 @@ def _select_best_with_one_se(
         candidates.append((result, float(mean), float(se)))
 
     if not candidates:
-        # No reliable K-fold trials -> defer to Ray Tune's single-best lookup,
-        # preserving the pre-K-fold behavior. ``metric`` / ``mode`` are passed
-        # explicitly because ``TuneConfig`` no longer carries them (the
-        # scheduler owns them; Ray Tune disallows both -- see tune_models.py).
+        # No reliable K-fold trials (single-split runs, or K-fold runs whose
+        # K-1 folds were NaN). For checkpoint-based trainables, ``results`` has
+        # already been narrowed to checkpoint-carrying trials, so pick the best
+        # by metric directly -- ``get_best_result`` would re-scan the full grid
+        # and could land on a crashed, checkpoint-less trial (issue #123).
+        if model_type in _CHECKPOINT_MODEL_TYPES:
+            scored = [
+                (r, _metric_value(r, metric))
+                for r in results
+                if _metric_value(r, metric) is not None
+            ]
+            return min(scored, key=lambda rv: sign * float(rv[1]))[0]
+        # Otherwise defer to Ray Tune's single-best lookup, preserving the
+        # pre-K-fold behavior. ``metric`` / ``mode`` are passed explicitly
+        # because ``TuneConfig`` no longer carries them (the scheduler owns
+        # them; Ray Tune disallows both -- see tune_models.py).
         return result_grid.get_best_result(metric=metric, mode=mode, scope="all")
 
     # Best by sign-adjusted mean (lower-is-better -> sign=+1, etc.).

--- a/ritme/tests/test_evaluate_models.py
+++ b/ritme/tests/test_evaluate_models.py
@@ -36,7 +36,7 @@ class TestEvaluateModels(unittest.TestCase):
         self.result.checkpoint = MagicMock()
         self.result.checkpoint.to_directory.return_value = "/test/checkpoint_dir"
 
-        self.result.metrics = {"model_path": "/fake/model/path"}
+        self.result.metrics = {"model_path": "/fake/model/path", "rmse_val": 1.0}
 
         self.result.path = "/fake/trial/dir"
         self.result.config = {
@@ -47,6 +47,9 @@ class TestEvaluateModels(unittest.TestCase):
 
         self.result_grid = MagicMock()
         self.result_grid.get_best_result.return_value = self.result
+        # Iterate to the (checkpoint-carrying) result so selection can run for
+        # checkpoint-based trainables (xgb / nn) without falling back.
+        self.result_grid.__iter__ = lambda _self: iter([self.result])
         self.mock_taxonomy_df = pd.DataFrame({"species": ["A", "B"], "count": [10, 20]})
         self.mock_model = MagicMock()
 
@@ -632,10 +635,17 @@ class TestBuildDesignMatrix(unittest.TestCase):
 
 
 def _make_mock_result(metrics: dict, config: dict):
-    """Build a MagicMock standing in for a Ray Tune ``Result`` row."""
+    """Build a MagicMock standing in for a Ray Tune ``Result`` row.
+
+    A real ``Result`` always carries a ``checkpoint`` attribute; default it to a
+    non-None mock so trials look deployable unless a test overrides it (see
+    ``_make_checkpoint_result``).
+    """
     r = MagicMock(spec=Result)
     r.metrics = metrics
     r.config = config
+    r.checkpoint = MagicMock()
+    r.error = None
     return r
 
 
@@ -1045,6 +1055,100 @@ class TestOneStandardErrorRule(unittest.TestCase):
             "linreg", {"nb_features": 50}, {"alpha": "n/a", "l1_ratio": 0.5}
         )
         self.assertLess(k_present, k_garbage)
+
+
+def _make_checkpoint_result(metrics, config, *, has_checkpoint, error=None):
+    """Mock ``Result`` whose ``checkpoint`` is set or ``None`` (crashed trial)."""
+    r = _make_mock_result(metrics, config)
+    r.checkpoint = MagicMock() if has_checkpoint else None
+    r.error = error
+    return r
+
+
+class TestCheckpointlessTrialSelection(unittest.TestCase):
+    """Trials of checkpoint-based trainables (xgb / nn) that report a metric but
+    crash before saving a checkpoint (OOM kill, SIGSEGV, node loss) appear in the
+    ResultGrid with ``checkpoint is None``. They must never be selected as best --
+    their loader would dereference ``None`` (issue #123)."""
+
+    def test_skips_checkpointless_best_trial_on_fallback_path(self):
+        # Exact issue #123 reproduction: best-scoring trial has no checkpoint,
+        # neither trial reports ``_se`` (single-split -> fallback path).
+        crashed = _make_checkpoint_result(
+            {"rmse_val": 1.0, "nb_features": 100},
+            {"max_depth": 6},
+            has_checkpoint=False,
+            error="oom-kill",
+        )
+        deployable = _make_checkpoint_result(
+            {"rmse_val": 2.0, "nb_features": 80},
+            {"max_depth": 4},
+            has_checkpoint=True,
+        )
+        rg = MagicMock()
+        rg.__iter__ = lambda self: iter([crashed, deployable])
+        rg.get_best_result.side_effect = AssertionError(
+            "must not defer to get_best_result for checkpoint-based trainables"
+        )
+        with self.assertWarns(UserWarning):
+            chosen = _select_best_with_one_se(rg, "rmse_val", "min", "xgb")
+        self.assertIs(chosen, deployable)
+
+    def test_checkpointless_trial_with_se_excluded_from_band(self):
+        # K-fold trial with the best mean + finite SE but no checkpoint (crashed
+        # after a running-fold report, before the final checkpoint report) must
+        # be dropped from the 1-SE band, not anchor it.
+        crashed_best = _make_checkpoint_result(
+            {"rmse_val_mean": 1.0, "rmse_val_se": 0.01, "nb_features": 100},
+            {"max_depth": 6},
+            has_checkpoint=False,
+            error="SIGSEGV",
+        )
+        deployable = _make_checkpoint_result(
+            {"rmse_val_mean": 1.5, "rmse_val_se": 0.5, "nb_features": 80},
+            {"max_depth": 4},
+            has_checkpoint=True,
+        )
+        rg = MagicMock()
+        rg.__iter__ = lambda self: iter([crashed_best, deployable])
+        chosen = _select_best_with_one_se(rg, "rmse_val", "min", "nn_reg")
+        self.assertIs(chosen, deployable)
+
+    def test_raises_when_every_trial_lacks_a_checkpoint(self):
+        a = _make_checkpoint_result(
+            {"rmse_val": 1.0, "nb_features": 100},
+            {"max_depth": 6},
+            has_checkpoint=False,
+            error="oom-kill",
+        )
+        b = _make_checkpoint_result(
+            {"rmse_val": 2.0, "nb_features": 80},
+            {"max_depth": 4},
+            has_checkpoint=False,
+            error="SIGSEGV",
+        )
+        rg = MagicMock()
+        rg.__iter__ = lambda self: iter([a, b])
+        with self.assertRaises(RuntimeError):
+            _select_best_with_one_se(rg, "rmse_val", "min", "xgb")
+
+    def test_sklearn_selection_unaffected_by_checkpoint_filter(self):
+        # sklearn / trac trainables never attach a checkpoint (their artifact is
+        # ``model_path``); the checkpoint filter must not touch their selection.
+        crashed_like = _make_checkpoint_result(
+            {"rmse_val": 1.0, "nb_features": 100},
+            {"alpha": 0.01},
+            has_checkpoint=False,
+        )
+        rg = MagicMock()
+        sentinel = MagicMock()
+        rg.get_best_result.return_value = sentinel
+        rg.__iter__ = lambda self: iter([crashed_like])
+        chosen = _select_best_with_one_se(rg, "rmse_val", "min", "linreg")
+        rg.get_best_result.assert_called_once_with(
+            metric="rmse_val", mode="min", scope="all"
+        )
+        self.assertIs(chosen, sentinel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`retrieve_n_init_best_models` selected the "best" trial from a Ray Tune
`ResultGrid` by reported metric alone, never checking that the chosen trial
actually persisted a model artifact. A trial that crashed mid-training
(OOM kill, SIGSEGV, Ray actor / node loss) is kept in the final `ResultGrid`
with a metric reported before the crash but `result.checkpoint is None`. For
checkpoint-based trainables (`xgb`, `xgb_class`, `nn_reg`, `nn_class`,
`nn_corn`), if such a trial scored best, the loader dereferenced the missing
checkpoint and the whole run died at the very end with
`AttributeError: 'NoneType' object has no attribute 'to_directory'` —
writing no model, no `best_metrics.csv`, no `mlflow_logs.csv`. More likely on
high-memory-pressure sweeps where at least one worker is OOM-killed. 

This PR solves issue #123.

## What changed

- **`ritme/evaluate_models.py`**:
  - `_CHECKPOINT_MODEL_TYPES` — the set of trainables whose deployable
    artifact is a Ray Tune checkpoint (`xgb` / `xgb_class` / `nn_*`), as
    opposed to sklearn / trac models persisted to `model_path`.
  - `_drop_checkpointless_trials(result_grid, metric, model_type)` — returns
    only trials with a non-`None` checkpoint. Warns per skipped trial (its
    metric value and the Ray error status), and raises a clear `RuntimeError`
    if **every** trial crashed before saving a checkpoint, instead of the
    opaque `NoneType` crash.
  - `_select_best_with_one_se` — for checkpoint-based trainables, filters out
    checkpoint-less trials up front so a crashed trial can never anchor the
    one-standard-error band, and in the no-SE fallback picks the best by
    metric among the surviving trials rather than re-scanning the full grid
    via `get_best_result` (which could re-select the crashed trial). sklearn /
    trac selection is untouched — `checkpoint is None` is normal for them.
  - `_metric_value` — small helper shared by the selection paths.
- **`ritme/tests/test_evaluate_models.py`**: new `TestCheckpointlessTrialSelection`
  (4 tests) — the issue reproduction (best trial has no checkpoint → next
  deployable trial chosen, with a warning), a K-fold trial with finite SE but
  no checkpoint excluded from the band, all-crashed grid raising `RuntimeError`,
  and a guard that sklearn selection is unaffected by the filter. `setUp` and
  `_make_mock_result` now give mock results a checkpoint by default (mirroring
  a real `Result`).
